### PR TITLE
fix: Remove unused directives

### DIFF
--- a/sekoia_automation/cli.py
+++ b/sekoia_automation/cli.py
@@ -15,8 +15,8 @@ app = typer.Typer(
     help="SEKOIA.IO's automation helper to generate playbook modules",
     rich_markup_mode="markdown",
 )
-OptionalPath = Optional[Path]  # noqa: UP007  `Path | None` is not supported by typer
-OptionalStr = Optional[str]  # noqa: UP007  `Path | None` is not supported by typer
+OptionalPath = Optional[Path]
+OptionalStr = Optional[str]
 
 
 @app.command(name="generate-files-from-code")


### PR DESCRIPTION
Ruff [v0.0.253](https://github.com/charliermarsh/ruff/releases/tag/v0.0.253) removed the need to annotate `noqa` when using `Optional[str]` instead of `str | None`.

The directives can be removed.