### PR TITLE
chore: Swtich from sonar to codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,20 +65,8 @@ jobs:
           name: Unit Test Results
           path: junit.xml
 
-      - name: SonarCloud scan
-        uses: sonarsource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-      - name: SonarQube Quality Gate check
-        id: sonar-cloud-quality-gate
-        uses: sonarsource/sonarqube-quality-gate-action@master
-        with:
-          scanMetadataReportFile: .scannerwork/report-task.txt
-        timeout-minutes: 5
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - name: Code Coverage
+        uses: codecov/codecov-action@v3
 
   EventFile:
     runs-on: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+    patch:
+      default:
+        target: 90%


### PR DESCRIPTION
Sonar cloud scans cannot be performed when the PR is created from a forked repository.

For this reason this PR moves away from Sonar and relies on codecov to add a code coverage gate.
We will lose the other analysis provided by sonar.