### PR TITLE
feat: Add liveness HTTP endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add support for config stored inside env variables
+- Add liveness HTTP endpoint to check if the trigger is still working
 
 ### Changed
 

--- a/sekoia_automation/connector.py
+++ b/sekoia_automation/connector.py
@@ -2,7 +2,7 @@ import uuid
 from collections.abc import Generator, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import wait as wait_futures
-from datetime import time
+from datetime import datetime, time
 from functools import cached_property
 from typing import Any
 from urllib.parse import urljoin
@@ -84,6 +84,7 @@ class Connector(Trigger):
         if not events:
             return []
 
+        self._last_events = datetime.utcnow()
         intake_host = self.configuration.intake_server
         batch_api = urljoin(intake_host, "/batch")
 

--- a/sekoia_automation/connector.py
+++ b/sekoia_automation/connector.py
@@ -30,6 +30,8 @@ class DefaultConnectorConfiguration(BaseModel):
 class Connector(Trigger):
     configuration: DefaultConnectorConfiguration
 
+    seconds_without_events = 3600
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._executor = ThreadPoolExecutor(kwargs.pop("executor_max_worker", 4))

--- a/sekoia_automation/module.py
+++ b/sekoia_automation/module.py
@@ -241,7 +241,12 @@ class Module:
         command = self.command or ""
 
         if command in self._items:
-            self._items[command](self).execute()
+            to_run = self._items[command](self)
+            try:
+                to_run.start_monitoring()
+                to_run.execute()
+            finally:
+                to_run.stop_monitoring()
         else:
             error = f"Could not find any Action or Trigger matching command '{command}'"
             sentry_sdk.capture_message(error, "error")
@@ -405,3 +410,13 @@ class ModuleItem(ABC):
     @abstractmethod
     def execute(self) -> None:
         """To define in subclasses. Main method being called to run the ModuleItem."""
+
+    def start_monitoring(self) -> None:
+        """
+        Allow the Trigger or Action to start some background monitoring tasks
+        """
+
+    def stop_monitoring(self):
+        """
+        Stops the background monitoring operations
+        """

--- a/sekoia_automation/trigger.py
+++ b/sekoia_automation/trigger.py
@@ -277,6 +277,7 @@ class Trigger(ModuleItem):
         This is based on the date of the last sent events
         compared to the `seconds_without_events` threshold.
         """
+        delta = datetime.utcnow() - self._last_events
         if (
             self.seconds_without_events <= 0
             or datetime.utcnow() - self._last_events
@@ -284,9 +285,9 @@ class Trigger(ModuleItem):
         ):
             return True
 
-        delta = (datetime.utcnow() - self._last_events).seconds
         self.log(
-            message=f"The trigger didn't send events for {delta} seconds", level="error"
+            message=f"The trigger didn't send events for {delta.seconds} seconds",
+            level="error",
         )
         return False
 

--- a/sekoia_automation/trigger.py
+++ b/sekoia_automation/trigger.py
@@ -278,15 +278,14 @@ class Trigger(ModuleItem):
         compared to the `seconds_without_events` threshold.
         """
         delta = datetime.utcnow() - self._last_events
-        if (
-            self.seconds_without_events <= 0
-            or datetime.utcnow() - self._last_events
-            < timedelta(seconds=self.seconds_without_events)
+        if self.seconds_without_events <= 0 or delta < timedelta(
+            seconds=self.seconds_without_events
         ):
             return True
 
         self.log(
-            message=f"The trigger didn't send events for {delta.seconds} seconds",
+            message=f"The trigger didn't send events for {delta.seconds} seconds, "
+            f"it will be restarted.",
             level="error",
         )
         return False


### PR DESCRIPTION
Adds a simple HTTP server with an `health` endpoint to allow external watchers to query the current health of the running trigger.

For now a traditional trigger is always considered alive, and a connector is considered alive if it sent at least an event in the last 3600 seconds.
