### PR TITLE
Improve event forwarding

### DIFF
--- a/sekoia_automation/connector.py
+++ b/sekoia_automation/connector.py
@@ -80,7 +80,7 @@ class Connector(Trigger):
         except Exception as ex:
             self.log_exception(ex, message=f"Failed to forward {len(chunk)} events")
 
-    def push_events_to_intakes(self, events: list[str]) -> list:
+    def push_events_to_intakes(self, events: list[str], sync: bool = False) -> list:
         # no event to push
         if not events:
             return []
@@ -96,13 +96,21 @@ class Connector(Trigger):
         if self._stop_event.is_set():
             return []
         chunks = self._chunk_events(events, self.configuration.chunk_size)
-        futures = [
-            self._executor.submit(
-                self._send_chunk, batch_api, chunk_index, chunk, collect_ids
-            )
-            for chunk_index, chunk in enumerate(chunks)
-        ]
-        wait_futures(futures)
+
+        # if requested, or if the executor is down
+        if sync or not self.running:
+            # forward in sequence
+            for chunk_index, chunk in enumerate(chunks):
+                self._send_chunk(batch_api, chunk_index, chunk, collect_ids)
+        else:
+            # Parallelize the forwarding
+            futures = [
+                self._executor.submit(
+                    self._send_chunk, batch_api, chunk_index, chunk, collect_ids
+                )
+                for chunk_index, chunk in enumerate(chunks)
+            ]
+            wait_futures(futures)
 
         # reorder event_ids according chunk index
         event_ids = [

--- a/sekoia_automation/connector.py
+++ b/sekoia_automation/connector.py
@@ -33,8 +33,9 @@ class Connector(Trigger):
     seconds_without_events = 3600
 
     def __init__(self, *args, **kwargs):
+        executor_max_worker = kwargs.pop("executor_max_worker", 4)
         super().__init__(*args, **kwargs)
-        self._executor = ThreadPoolExecutor(kwargs.pop("executor_max_worker", 4))
+        self._executor = ThreadPoolExecutor(executor_max_worker)
 
     def stop(self, *args, **kwargs):
         """

--- a/sekoia_automation/connector.py
+++ b/sekoia_automation/connector.py
@@ -93,8 +93,6 @@ class Connector(Trigger):
         collect_ids: dict[int, list] = {}
 
         # pushing the events
-        if self._stop_event.is_set():
-            return []
         chunks = self._chunk_events(events, self.configuration.chunk_size)
 
         # if requested, or if the executor is down

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -122,8 +122,25 @@ def test_push_event_to_intake_with_chunks_executor_stopped(
     test_connector, mocked_trigger_logs
 ):
     test_connector.stop()
+    url = "https://intake.sekoia.io/batch"
+    test_connector.configuration.chunk_size = 1
+    mocked_trigger_logs.post(
+        url, json={"event_ids": ["001"]}, additional_matcher=match_events("foo")
+    )
+    mocked_trigger_logs.post(
+        url, json={"event_ids": ["002"]}, additional_matcher=match_events("bar")
+    )
+    mocked_trigger_logs.post(
+        url, json={"event_ids": ["003"]}, additional_matcher=match_events("baz")
+    )
+    mocked_trigger_logs.post(
+        url, json={"event_ids": ["004"]}, additional_matcher=match_events("oof")
+    )
     result = test_connector.push_events_to_intakes(["foo", "bar", "baz", "oof"])
-    assert result == []
+    assert result is not None
+    assert len(result) == 4
+    assert mocked_trigger_logs.call_count == 4
+    assert result == ["001", "002", "003", "004"]
 
 
 def test_push_events_to_intakes_no_events(test_connector):


### PR DESCRIPTION
- Prevent option for the connector to be forwarded to the trigger
- Handle event forwarding when the executor is down to avoid events lost