### PR TITLE
fix: Reset error counter when pushing events to intake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Exit infinite loop when stop event is set
+- Reset error counter when pushing events to intake
+
 ## [1.1.2] - 2023-04-24
 
 ### Fixed

--- a/sekoia_automation/connector.py
+++ b/sekoia_automation/connector.py
@@ -84,6 +84,8 @@ class Connector(Trigger):
         if not events:
             return []
 
+        # Reset the consecutive error count
+        self._error_count = 0
         self._last_events_time = datetime.utcnow()
         intake_host = self.configuration.intake_server
         batch_api = urljoin(intake_host, "/batch")


### PR DESCRIPTION
Reset the error counter when pushing events to intake so the connector exits when we have 5 consecutive errors and not 5 errors in the life of the connector.

This is already done in the "regular" triggers when sending events.