### PR TITLE
open a metrics exporter when the trigger starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add support for TLS client authentication in S3 storage
+- Launch the metrics exporter when the trigger starts
 
 ## [1.2.0] - 2023-05-10
 

--- a/tests/connectors/test_connector.py
+++ b/tests/connectors/test_connector.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from tenacity import Retrying
@@ -18,18 +18,19 @@ class DummyConnector(Connector):
 
 @pytest.fixture
 def test_connector(storage, mocked_trigger_logs):
-    test_connector = DummyConnector(data_path=storage)
-    test_connector.send_event = Mock()
+    with patch("sentry_sdk.set_tag"):
+        test_connector = DummyConnector(data_path=storage)
+        test_connector.send_event = Mock()
 
-    test_connector.trigger_activation = "2022-03-14T11:16:14.236930Z"
-    test_connector.configuration = {"intake_key": ""}
+        test_connector.trigger_activation = "2022-03-14T11:16:14.236930Z"
+        test_connector.configuration = {"intake_key": ""}
 
-    test_connector.log = Mock()
-    test_connector.log_exception = Mock()
+        test_connector.log = Mock()
+        test_connector.log_exception = Mock()
 
-    yield test_connector
+        yield test_connector
 
-    test_connector.stop()
+        test_connector.stop()
 
 
 def test_forward_events(test_connector):


### PR DESCRIPTION
Automatically start the metrics exporter when starting the trigger (Will replace exporter instructions in connectors).