### PR TITLE
feat: Add graceful period before logging a critical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for TLS client authentication in S3 storage
 - Launch the metrics exporter when the trigger starts
 - Do not exit on critical
+- Add graceful period before logging a critical error
 
 ## [1.2.0] - 2023-05-10
 

--- a/sekoia_automation/trigger.py
+++ b/sekoia_automation/trigger.py
@@ -349,7 +349,7 @@ class Trigger(ModuleItem):
             * 12 hours would exit after 3 hours
             * 1 day would exit after 5 hours
             * 2 days would exit after 10 hours
-            * 5 days would exit after 24 hours
+            * >=5 days would exit after 24 hours
         """
         if self._error_count < 5 or self._critical_log_sent:
             return False


### PR DESCRIPTION
Add graceful period in which 5 errors won't trigger a critical error, so the trigger can keep running.

This period depends on the time the trigger has been running and is limited to 24 hours.