### PR TITLE
Fix a typing issue when adding secrets to a module

### DIFF
--- a/sekoia_automation/action.py
+++ b/sekoia_automation/action.py
@@ -208,7 +208,11 @@ class Action(ModuleItem):
                 for k, v in response.json()["module_configuration"]["value"].items()
                 if k in self.module.manifest_secrets()
             }
-            self.module.configuration |= secrets
+            if isinstance(self.module.configuration, dict):
+                self.module.configuration |= secrets
+            else:
+                for key, value in secrets.items():
+                    setattr(self.module.configuration, key, value)
         else:
             self._send_request(data, verb="PATCH")
 


### PR DESCRIPTION
The module configuration can either be a dict or a more complex object such as OpenAIConfiguration
We added a check and in case the config is not a dict, we set the secrets using setattr