### PR TITLE
Fix: Minor fixes in scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.3] - 2023-06-13
+
 ### Fixed:
 
 - In `synchronize-lib` error display docker image name used previously
+- In module template don't use a specific python package index
 
 ## [1.3.2] - 2023-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed:
+
+- In `synchronize-lib` error display docker image name used previously
+
 ## [1.3.2] - 2023-06-09
 
 ### Changed

--- a/sekoia_automation/scripts/new_module/template/{{cookiecutter.module_dir}}/pyproject.toml
+++ b/sekoia_automation/scripts/new_module/template/{{cookiecutter.module_dir}}/pyproject.toml
@@ -4,10 +4,6 @@ version = "0.0"
 description = ""
 authors = []
 
-[[tool.poetry.source]]
-name = "SEKOIA.IO"
-url = "https://delivery.sekoia.io/nexus/repository/pypi-test/simple"
-
 [tool.poetry.dependencies]
 python = ">=3.10,<3.11"
 sekoia-automation-sdk = "^1.0"

--- a/sekoia_automation/scripts/sync_library.py
+++ b/sekoia_automation/scripts/sync_library.py
@@ -306,8 +306,6 @@ class SyncLibrary:
             },
         )
 
-        print(response.status_code)
-
         return response.status_code == 200
 
     def load_module(self, module_path: Path):

--- a/sekoia_automation/scripts/sync_library.py
+++ b/sekoia_automation/scripts/sync_library.py
@@ -306,6 +306,8 @@ class SyncLibrary:
             },
         )
 
+        print(response.status_code)
+
         return response.status_code == 200
 
     def load_module(self, module_path: Path):
@@ -323,11 +325,12 @@ class SyncLibrary:
         with manifest_path.open() as fd:
             module_info = json.load(fd)
 
+        docker_name = self._get_module_docker_name(module_info)
         if self.registry_check and not self.check_image_on_registry(
-            self._get_module_docker_name(module_info), module_info["version"]
+            docker_name, module_info["version"]
         ):
             print(
-                f"[bold red][!] Image {module_info['docker']}:{module_info['version']} "
+                f"[bold red][!] Image {docker_name}:{module_info['version']} "
                 f"not available on registry"
             )
             raise typer.Exit(code=1)


### PR DESCRIPTION
- In `synchronize-lib` error display docker image name used previously
- In module template don't use a specific python package index