### PR TITLE
feat: Small improvements in triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- On critical error wait until the pod is killed instead of keep running
+
+### Changed
+
+- Increase time to wait without events before restarting the pod
+
 ## [1.3.9] - 2023-08-21
 
 ### Added

--- a/sekoia_automation/connector/__init__.py
+++ b/sekoia_automation/connector/__init__.py
@@ -30,7 +30,7 @@ class DefaultConnectorConfiguration(BaseModel):
 class Connector(Trigger):
     configuration: DefaultConnectorConfiguration
 
-    seconds_without_events = 3600
+    seconds_without_events = 3600 * 6
 
     def __init__(self, *args, **kwargs):
         executor_max_worker = kwargs.pop("executor_max_worker", 4)

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -296,6 +296,7 @@ def test_configuration_errors_are_critical(_, mocked_trigger_logs):
                 raise TriggerConfigurationError
 
     trigger = TestTrigger()
+    trigger._STOP_EVENT_WAIT = 0.1
     with pytest.raises(SystemExit), patch.object(
         Module, "load_config", return_value={}
     ):
@@ -322,6 +323,7 @@ def test_too_many_errors_critical_log(_, mocked_trigger_logs):
 
     trigger = TestTrigger()
     trigger._error_count = 4
+    trigger._STOP_EVENT_WAIT = 0.1
     with pytest.raises(SystemExit), patch.object(
         Module, "load_config", return_value={}
     ):


### PR DESCRIPTION
### Added

- On critical error wait until the pod is killed instead of keep running

### Changed

- Increase time to wait without events before restarting the pod