### PR TITLE
feat: Send logs by batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Increase time to wait without events before restarting the pod
+- Send logs by batch
 
 ## [1.3.9] - 2023-08-21
 


### PR DESCRIPTION
Send trigger logs by batch. A batch is sent if:
* An error or a critical log is received
* The batch reached 50 logs
* The first pending log has been waiting for more than 5 seconds

With this implementation a log may be waiting to be sent for more than 5 seconds if the trigger doesn't create new logs. I think it is acceptable because important logs are sent immediately and it avoid to add complexity to the code.