### PR TITLE
AIO: remove redundant logs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- remove redundant logs for connectors
+
 ## [1.10.0] - 2023-12-12
 
 ## Added

--- a/sekoia_automation/aio/connector.py
+++ b/sekoia_automation/aio/connector.py
@@ -109,21 +109,12 @@ class AsyncConnector(Connector, ABC):
         self._last_events_time = datetime.utcnow()
         batch_api = urljoin(self.configuration.intake_server, "batch")
 
-        self.log(f"Push {len(events)} events to intakes")
-
         result_ids = []
 
         chunks = self._chunk_events(events)
 
         async with self.session() as session:
             for chunk_index, chunk in enumerate(chunks):
-                self.log(
-                    "Start to push chunk {} with data count {} to intakes".format(
-                        chunk_index,
-                        len(chunk),
-                    )
-                )
-
                 request_body = {
                     "intake_key": self.configuration.intake_key,
                     "jsons": chunk,
@@ -141,16 +132,11 @@ class AsyncConnector(Connector, ABC):
                                 error_message = f"Chunk {chunk_index} error: {error}"
                                 exception = RuntimeError(error_message)
 
-                                self.log(message=error_message, level="error")
                                 self.log_exception(exception)
 
                                 raise exception
 
                             result = await response.json()
-
-                            self.log(
-                                f"Successfully pushed chunk {chunk_index} to intakes"
-                            )
 
                             result_ids.extend(result.get("event_ids", []))
 


### PR DESCRIPTION
Remove some logs, from connectors, that are redundant with existing ones in order to reduce the number of requests to the API