### PR TITLE
Connector: use HTTP session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- When forwarding events, use a http session to reuse the existing HTTP connection
+
 ## [1.11.1] - 2024-01-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.11.1] - 2023-01-29
+## [1.11.1] - 2024-01-29
 
 ### Fixed
 
 - Fixes connector configuration file name
 
-## [1.11.0] - 2023-01-17
+## [1.11.0] - 2024-01-17
 
 ### Changed
 

--- a/sekoia_automation/connector/__init__.py
+++ b/sekoia_automation/connector/__init__.py
@@ -98,6 +98,12 @@ class Connector(Trigger, ABC):
         )
 
     @cached_property
+    def _http_session(self) -> requests.Session:
+        session = requests.Session()
+        session.headers.update({"User-Agent": self._connector_user_agent})
+        return session
+
+    @cached_property
     def _connector_user_agent(self) -> str:
         return f"sekoiaio-connector-{self.configuration.intake_key}"
 
@@ -133,10 +139,9 @@ class Connector(Trigger, ABC):
 
             for attempt in self._retry():
                 with attempt:
-                    res: Response = requests.post(
+                    res: Response = self._http_session.post(
                         batch_api,
                         json=request_body,
-                        headers={"User-Agent": self._connector_user_agent},
                         timeout=30,
                     )
                     res.raise_for_status()


### PR DESCRIPTION
When forwarding events to sekoai.io, use a Requests' session in order to reuse existing HTTP connections (and speed up requests)