### PR TITLE
Linting:  Fix issue with ruff

### DIFF
--- a/sekoia_automation/module.py
+++ b/sekoia_automation/module.py
@@ -43,7 +43,7 @@ class Module:
         self._configuration: dict | BaseModel | None = None
         self._manifest: dict | None = None
         self._community_uuid: str | None = None
-        self._items: dict[str, type["ModuleItem"]] = {}
+        self._items: dict[str, type[ModuleItem]] = {}
         self._playbook_uuid: str | None = None
         self._playbook_run_uuid: str | None = None
         self._node_run_uuid: str | None = None


### PR DESCRIPTION
The last version of ruff disapproves quotes for type annotation ([UP037](https://docs.astral.sh/ruff/rules/quoted-annotation/)).
This issue prevents the success of PRs