### PR TITLE
Module generator - change default title

### DIFF
--- a/sekoia_automation/scripts/new_module/template/{{cookiecutter.module_dir}}/pyproject.toml
+++ b/sekoia_automation/scripts/new_module/template/{{cookiecutter.module_dir}}/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "SEKOIA's automation module for {{cookiecutter.module_name.capitalize()}}"
+name = "Automation module for {{cookiecutter.module_name.capitalize()}}"
 version = "0.0"
 description = ""
 authors = []


### PR DESCRIPTION
The single quote goes automatically in the virtual env's path, causing errors