### PR TITLE
Module Publication: fix the way to handle docker image information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Change the way to handle docker image information when publishing a module
+
 ## 1.17.0 - 2024-11-04
 
 ### Added


### PR DESCRIPTION
The docker image can be got from the module of the manifest or computed.
However, according to the way the docker image is got, the value can be inconsistent. I changed the way to represent the docker image information to always get the right information.