### PR TITLE
fix: Fixes synchronization script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 1.17.1 - 2024-11-04
+
 ### Fixed
 
 - Change the way to handle docker image information when publishing a module
+- Fix the module synchronization script
 
 ## 1.17.0 - 2024-11-04
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "sekoia-automation-sdk"
 
-version = "1.17.0"
+version = "1.17.1"
 description = "SDK to create Sekoia.io playbook modules"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
Setting value to `None` when not in the manifest is creating an issue for optional fields that can't be null, i.e. the release status 