### PR TITLE
include CONFIGURE.md in generated documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Include CONFIGURE.md into the generated documentation of automation modules
+
 ## 1.18.3
 
 ### Changed

--- a/sekoia_automation/scripts/documentation/templates/module.md
+++ b/sekoia_automation/scripts/documentation/templates/module.md
@@ -101,6 +101,13 @@ This module accepts no configuration.
 {%- endfor -%}{# /actions #}
 {%- endif -%}{# /actions #}
 
+{%- if setup %}
+## Set up
+
+{{ setup }}
+
+{%- endif %}
+
 ## Extra
 
 Module **`{{manifest.name}}` v{{manifest.version}}**


### PR DESCRIPTION
Include CONFIGURE.md and docs/assets/ into the generated documentation of automation modules