### PR TITLE
Script: fix the pydantic import in the template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fix the pydantic import in models.py of the template used to generate new modules
+
 ## 1.18.4
 
 ### Changed

--- a/sekoia_automation/scripts/new_module/template/{{cookiecutter.module_dir}}/{{cookiecutter.module_name.lower().replace(" ", "_")}}_modules/models.py
+++ b/sekoia_automation/scripts/new_module/template/{{cookiecutter.module_dir}}/{{cookiecutter.module_name.lower().replace(" ", "_")}}_modules/models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 class {{cookiecutter.module_name.title().replace(" ", "")}}ModuleConfiguration(BaseModel):


### PR DESCRIPTION
 Now, as we use pydantic V2, as a dependency of the sdk, the pydantic import, in the cookie-cutter template we use to generate a new module, is incorrect.
 The PR fixes it.