### PR TITLE
feat: Release 1.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.19.1 - 2025-07-30
+
 ### Fixed
 
 - Set aiohttp as a mandatory dependency for the SDK

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "sekoia-automation-sdk"
 
-version = "1.19.0"
+version = "1.19.1"
 description = "SDK to create Sekoia.io playbook modules"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
## Summary by Sourcery

Release version 1.19.1, update changelog, and bump package version

Bug Fixes:
- Set aiohttp as a mandatory dependency for the SDK

Build:
- Bump SDK version to 1.19.1

Documentation:
- Add 1.19.1 release notes to the changelog