### PR TITLE
Asset connectors: Add users fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.19.3 - 2025-08-04
+
+### Fixed
+
+- Add users fields to enrichment 
+
 ## 1.19.2 - 2025-07-31
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "sekoia-automation-sdk"
 
-version = "1.19.2"
+version = "1.19.3"
 description = "SDK to create Sekoia.io playbook modules"
 license = "MIT"
 readme = "README.md"

--- a/sekoia_automation/asset_connector/models/ocsf/device.py
+++ b/sekoia_automation/asset_connector/models/ocsf/device.py
@@ -123,6 +123,7 @@ class DeviceDataObject(BaseModel):
 
     Firewall_status: Literal["Disabled", "Enabled"] | None = None
     Storage_encryption: EncryptionObject | None = None
+    Users: list[str] | None = None
 
 
 class DeviceEnrichmentObject(BaseModel):


### PR DESCRIPTION
As talked with stephanie : we have to add users to enrichments of a device

## Summary by Sourcery

Add Users field to device enrichment model, bump version to 1.19.3, and update changelog

New Features:
- Add Users field to DeviceDataObject enrichment model

Build:
- Update SDK version to 1.19.3

Documentation:
- Update CHANGELOG to document the new Users field