### PR TITLE
Generic API observability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "sekoia-automation-sdk"
 
-version = "1.20.3a2"
+version = "1.20.3a3"
 description = "SDK to create Sekoia.io playbook modules"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
Add some logs to observe the behavior of the generic API actions

## Summary by Sourcery

Enable debug-level logging for GenericAPIAction to output module configuration, request preparation, and response details, configured via the LOG_LEVEL environment variable; bump version

Enhancements:
- Add logging setup in GenericAPIAction __init__ to set log level from LOG_LEVEL
- Add debug logs for module configuration, request details (URL, verb, headers, params, body), and response details (status, headers, body)

Build:
- Bump package version to 1.20.3a3