### PR TITLE
SDK: release 1.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.22.1 - 2026-01-15
+
 ### Fixed
 
 - Fix some OCSF schema fields 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "sekoia-automation-sdk"
 
-version = "1.22.0"
+version = "1.22.1"
 description = "SDK to create Sekoia.io playbook modules"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
New release of the SDK

## Summary by Sourcery

Release SDK version 1.22.1 with updated changelog and version metadata.

Bug Fixes:
- Document fixes to certain OCSF schema fields in the changelog.

Build:
- Bump package version from 1.22.0 to 1.22.1 in project metadata.