### PR TITLE
SDK: add all async dependencies as required

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,33 +35,17 @@ dependencies = [
     "black>=25.11.0", # To format files in cli tools
     "uv",             # To lock requirements when creating new module
     "prometheus-client",
+    "aiobotocore>=2.20.0,<3",
+    "aiocsv>=1.2.4,<2",
+    "aiofiles>=23.1.0,<24",
     "aiohttp>=3.8.4,<4",
     "aiolimiter>=1.1.0,<2",
+    "boto3>=1.36.23,<2",
+    "loguru>=0.7.0,<0.8",
     "jsonschema>=4.22.0,<5",
     "flask>=3.1.2,<4",
     "cachetools>=6.2.3",
 ]
-
-[project.optional-dependencies]
-all = [
-    "aiobotocore>=2.20.0,<3",
-    "boto3>=1.36.23,<2",
-    "aiofiles>=23.1.0,<24",
-    "aiocsv>=1.2.4,<2",
-    "loguru>=0.7.0,<0.8",
-]
-async-aws = [
-    "aiobotocore>=2.20.0,<3",
-    "boto3>=1.36.23,<2",
-]
-async-http = [
-    "aiofiles>=23.1.0,<24",
-]
-async-files = [
-    "aiofiles>=23.1.0,<24",
-    "aiocsv>=1.2.4,<2",
-]
-logging = ["loguru>=0.7.0,<0.8"]
 
 [build-system]
 requires = ["hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -2175,14 +2175,19 @@ name = "sekoia-automation-sdk"
 version = "1.22.2"
 source = { editable = "." }
 dependencies = [
+    { name = "aiobotocore" },
+    { name = "aiocsv" },
+    { name = "aiofiles" },
     { name = "aiohttp" },
     { name = "aiolimiter" },
     { name = "black" },
+    { name = "boto3" },
     { name = "cachetools" },
     { name = "cookiecutter" },
     { name = "flask" },
     { name = "jinja2" },
     { name = "jsonschema" },
+    { name = "loguru" },
     { name = "orjson" },
     { name = "prometheus-client" },
     { name = "pydantic" },
@@ -2195,29 +2200,6 @@ dependencies = [
     { name = "tenacity" },
     { name = "typer" },
     { name = "uv" },
-]
-
-[package.optional-dependencies]
-all = [
-    { name = "aiobotocore" },
-    { name = "aiocsv" },
-    { name = "aiofiles" },
-    { name = "boto3" },
-    { name = "loguru" },
-]
-async-aws = [
-    { name = "aiobotocore" },
-    { name = "boto3" },
-]
-async-files = [
-    { name = "aiocsv" },
-    { name = "aiofiles" },
-]
-async-http = [
-    { name = "aiofiles" },
-]
-logging = [
-    { name = "loguru" },
 ]
 
 [package.dev-dependencies]
@@ -2243,25 +2225,19 @@ lint = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiobotocore", marker = "extra == 'all'", specifier = ">=2.20.0,<3" },
-    { name = "aiobotocore", marker = "extra == 'async-aws'", specifier = ">=2.20.0,<3" },
-    { name = "aiocsv", marker = "extra == 'all'", specifier = ">=1.2.4,<2" },
-    { name = "aiocsv", marker = "extra == 'async-files'", specifier = ">=1.2.4,<2" },
-    { name = "aiofiles", marker = "extra == 'all'", specifier = ">=23.1.0,<24" },
-    { name = "aiofiles", marker = "extra == 'async-files'", specifier = ">=23.1.0,<24" },
-    { name = "aiofiles", marker = "extra == 'async-http'", specifier = ">=23.1.0,<24" },
+    { name = "aiobotocore", specifier = ">=2.20.0,<3" },
+    { name = "aiocsv", specifier = ">=1.2.4,<2" },
+    { name = "aiofiles", specifier = ">=23.1.0,<24" },
     { name = "aiohttp", specifier = ">=3.8.4,<4" },
     { name = "aiolimiter", specifier = ">=1.1.0,<2" },
     { name = "black", specifier = ">=25.11.0" },
-    { name = "boto3", marker = "extra == 'all'", specifier = ">=1.36.23,<2" },
-    { name = "boto3", marker = "extra == 'async-aws'", specifier = ">=1.36.23,<2" },
+    { name = "boto3", specifier = ">=1.36.23,<2" },
     { name = "cachetools", specifier = ">=6.2.3" },
     { name = "cookiecutter", specifier = ">=2.1,<3" },
     { name = "flask", specifier = ">=3.1.2,<4" },
     { name = "jinja2", specifier = ">=3.0.3,<4" },
     { name = "jsonschema", specifier = ">=4.22.0,<5" },
-    { name = "loguru", marker = "extra == 'all'", specifier = ">=0.7.0,<0.8" },
-    { name = "loguru", marker = "extra == 'logging'", specifier = ">=0.7.0,<0.8" },
+    { name = "loguru", specifier = ">=0.7.0,<0.8" },
     { name = "orjson", specifier = ">=3.8,<4" },
     { name = "prometheus-client" },
     { name = "pydantic", specifier = ">=2.10,<3" },
@@ -2275,7 +2251,6 @@ requires-dist = [
     { name = "typer", specifier = ">=0.20" },
     { name = "uv" },
 ]
-provides-extras = ["all", "async-aws", "async-http", "async-files", "logging"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
In addition to https://github.com/SEKOIA-IO/sekoia-automation-sdk/pull/213, I propose moving all async dependencies as required.

## Summary by Sourcery

Build:
- Move async-related packages (aiobotocore, aiocsv, aiofiles, boto3, loguru) from optional extras into the main dependency list and remove the corresponding optional-dependency groups from pyproject.toml.