### PR TITLE
SDK: release 1.22.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.22.4 - 2026-03-05
+
 ### Fixed
 
 - Fix OCSF device model: simplify `DeviceTypeId`/`DeviceTypeStr` enums, add `Full_qualified_domain_name` field to `DeviceDataObject`, and make `DeviceEnrichmentObject` fields optional

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sekoia-automation-sdk"
-version = "1.22.3"
+version = "1.22.4"
 description = "SDK to create Sekoia.io playbook modules"
 authors = [{ name = "Sekoia.io" }]
 requires-python = ">=3.11,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -2172,7 +2172,7 @@ wheels = [
 
 [[package]]
 name = "sekoia-automation-sdk"
-version = "1.22.3"
+version = "1.22.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiobotocore" },


### PR DESCRIPTION
This pull request updates the package version and documents a bug fix related to device models in the OCSF integration.

Version update:

* Bumped the version in `pyproject.toml` from `1.22.3` to `1.22.4`.

OCSF device model fixes:

* Added a changelog entry for version `1.22.4` describing the following fixes: simplified `DeviceTypeId`/`DeviceTypeStr` enums, added the `Full_qualified_domain_name` field to `DeviceDataObject`, and made `DeviceEnrichmentObject` fields optional.

## Summary by Sourcery

Release version 1.22.4 of the SDK and document the OCSF device model bug fix.

Bug Fixes:
- Document the OCSF device model fix covering enum simplification, a new device data field, and optional enrichment fields.

Build:
- Bump the SDK package version from 1.22.3 to 1.22.4 in project configuration.

Documentation:
- Add a changelog entry for version 1.22.4 describing the OCSF device model fix.