### PR TITLE
Script: Fix the template to generate new automation module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fix the template to generate new automation module to work with uv
+
 ## 1.22.4 - 2026-03-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix the template to generate new automation module to work with uv
+- Fix the template for generating new automation modules to work with uv
 
 ## 1.22.4 - 2026-03-05
 

--- a/sekoia_automation/scripts/new_module/template/hooks/post_gen_project.sh
+++ b/sekoia_automation/scripts/new_module/template/hooks/post_gen_project.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-uv add sekoia-automation-sdk@latest
 uv lock

--- a/sekoia_automation/scripts/new_module/template/{{cookiecutter.module_dir}}/pyproject.toml
+++ b/sekoia_automation/scripts/new_module/template/{{cookiecutter.module_dir}}/pyproject.toml
@@ -3,7 +3,7 @@ name = "{{cookiecutter.module_name.lower().replace(' ', '_')}}-automation-module
 version = "0.0"
 description = ""
 authors = []
-requires-python=">=3.11,<4"
+requires-python = ">=3.11,<4"
 
 dependencies = [
     "sekoia-automation-sdk"

--- a/sekoia_automation/scripts/new_module/template/{{cookiecutter.module_dir}}/pyproject.toml
+++ b/sekoia_automation/scripts/new_module/template/{{cookiecutter.module_dir}}/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
-name = "Automation module for {{cookiecutter.module_name.capitalize()}}"
+name = "{{cookiecutter.module_name.capitalize()}}-automation-module"
 version = "0.0"
 description = ""
 authors = []
-package-mode = false
+requires-python=">=3.11,<3.15"
 
-[project.dependencies]
-python = "^3.11"
-sekoia-automation-sdk = "^1.0"
+dependencies = [
+    "sekoia-automation-sdk"
+]
 
 [project.dependency-group.dev]
 pytest = "*"
@@ -18,6 +18,9 @@ requests-mock = "*"
 [build-system]
 requires = ["uv_build>=0.9.7,<0.10.0"]
 build-backend = "uv_build"
+
+[tool.uv]
+package = false
 
 [tool.black]
 line-length = 119

--- a/sekoia_automation/scripts/new_module/template/{{cookiecutter.module_dir}}/pyproject.toml
+++ b/sekoia_automation/scripts/new_module/template/{{cookiecutter.module_dir}}/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
-name = "{{cookiecutter.module_name.capitalize()}}-automation-module"
+name = "{{cookiecutter.module_name.lower().replace(' ', '_')}}-automation-module"
 version = "0.0"
 description = ""
 authors = []
-requires-python=">=3.11,<3.15"
+requires-python=">=3.11,<4"
 
 dependencies = [
     "sekoia-automation-sdk"
@@ -16,7 +16,7 @@ requests = "*"
 requests-mock = "*"
 
 [build-system]
-requires = ["uv_build>=0.9.7,<0.10.0"]
+requires = ["uv_build>=0.9.7,<1.0.0"]
 build-backend = "uv_build"
 
 [tool.uv]


### PR DESCRIPTION
This pull request fixes the template for generating new automation modules to ensure compatibility with the `uv` package manager. The changes update the generated `pyproject.toml` structure, adjust dependency handling, and correct the post-generation script.

Changelog update:

* Added an entry to the changelog noting the fix for the automation module template to work with uv.

## Summary by Sourcery

Update the automation module template to be compatible with the uv package manager and document the fix in the changelog.

Bug Fixes:
- Adjust the generated automation module's pyproject configuration to use uv-compatible project metadata and dependency definitions.
- Ensure the post-generation script only locks dependencies with uv instead of mutating them.

Documentation:
- Add a changelog entry describing the fix for the automation module template with uv.