### PR TITLE
feat(ocsf): Add software information to asset connector models

### DIFF
--- a/sekoia_automation/asset_connector/models/ocsf/software.py
+++ b/sekoia_automation/asset_connector/models/ocsf/software.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from enum import IntEnum, StrEnum
 
 from pydantic import BaseModel
@@ -52,6 +53,42 @@ class PackageTypeStr(StrEnum):
     OTHER = "Other"
 
 
+class FileHash(BaseModel):
+    algorithm: str | None = None
+    value: str
+
+
+class Signature(BaseModel):
+    subject: str | None = None
+    issuer: str | None = None
+    valid: bool | None = None
+
+
+class Software(BaseModel):
+    uid: str | None = None
+    name: str | None = None
+    version: str | None = None
+
+    vendor_name: str | None = None
+    product_id: str | None = None
+
+    path: str | None = None
+    install_time: datetime | None = None
+    last_used_time: datetime | None = None
+
+    platform: str | None = None
+
+    cpe_name: str | None = None
+    package_url: str | None = None
+
+    hashes: list[FileHash] | None = None
+
+    is_signed: bool | None = None
+    signature: Signature | None = None
+
+    file_name: str | None = None
+
+
 class SoftwarePackage(BaseModel):
     name: str
     version: str
@@ -83,4 +120,5 @@ class SoftwareBillOfMaterials(BaseModel):
 
 class SoftwareOCSFModel(OCSFBaseModel):
     device: Device
+    software: Software
     sbom: SoftwareBillOfMaterials | None = None

--- a/sekoia_automation/asset_connector/models/ocsf/software.py
+++ b/sekoia_automation/asset_connector/models/ocsf/software.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from enum import IntEnum, StrEnum
 
 from pydantic import BaseModel, model_validator
@@ -80,8 +79,8 @@ class SoftwareEnrichmentObject(BaseModel):
     vendor_name: str | None = None
 
     path: str | None = None
-    install_time: datetime | None = None
-    last_used_time: datetime | None = None
+    install_time: float | None = None
+    last_used_time: float | None = None
 
     os: str | None = None
 
@@ -166,5 +165,6 @@ class SoftwareBillOfMaterials(BaseModel):
 
 class SoftwareOCSFModel(OCSFBaseModel):
     device: Device
+    software: SoftwareEnrichmentObject | None = None
     sbom: SoftwareBillOfMaterials | None = None
     enrichments: list[SoftwareEnrichmentObject] | None = None

--- a/sekoia_automation/asset_connector/models/ocsf/software.py
+++ b/sekoia_automation/asset_connector/models/ocsf/software.py
@@ -73,21 +73,17 @@ class SoftwareEnrichmentObject(BaseModel):
     name, version, vendor, installation path, and usage timestamps.
     """
 
-    uid: str | None = None
+    product_id: str | None = None
     product_name: str | None = None
     version: str | None = None
 
     vendor_name: str | None = None
-    product_id: str | None = None
 
     path: str | None = None
     install_time: datetime | None = None
     last_used_time: datetime | None = None
 
-    platform: str | None = None
-
-    cpe_name: str | None = None
-    package_url: str | None = None
+    os: str | None = None
 
     hashes: list[Fingerprint] | None = None
 

--- a/sekoia_automation/asset_connector/models/ocsf/software.py
+++ b/sekoia_automation/asset_connector/models/ocsf/software.py
@@ -10,7 +10,7 @@ from sekoia_automation.asset_connector.models.ocsf.device import Device
 class SBOMTypeId(IntEnum):
     UNKNOWN = 0
     SPDX = 1
-    CYCLOEDX = 2
+    CYCLONEDX = 2
     SWID = 3
     OTHER = 99
 
@@ -53,8 +53,8 @@ class PackageTypeStr(StrEnum):
     OTHER = "Other"
 
 
-class FileHash(BaseModel):
-    algorithm: str | None = None
+class Fingerprint(BaseModel):
+    algorithm_id: str | None = None
     value: str
 
 
@@ -64,9 +64,17 @@ class Signature(BaseModel):
     valid: bool | None = None
 
 
-class Software(BaseModel):
+class SoftwareEnrichmentObject(BaseModel):
+    """
+    Represents software-related information collected from a device.
+
+    This object describes applications installed on an endpoint and
+    enriches the context of a device by providing details such as
+    name, version, vendor, installation path, and usage timestamps.
+    """
+
     uid: str | None = None
-    name: str | None = None
+    product_name: str | None = None
     version: str | None = None
 
     vendor_name: str | None = None
@@ -81,15 +89,15 @@ class Software(BaseModel):
     cpe_name: str | None = None
     package_url: str | None = None
 
-    hashes: list[FileHash] | None = None
+    hashes: list[Fingerprint] | None = None
 
     is_signed: bool | None = None
     signature: Signature | None = None
 
-    file_name: str | None = None
+    binary_name: str | None = None
 
     @model_validator(mode="after")
-    def validate_signature_consistency(self) -> "Software":
+    def validate_signature_consistency(self) -> "SoftwareEnrichmentObject":
         has_signature = self.signature is not None
 
         if self.is_signed is None:
@@ -106,6 +114,15 @@ class Software(BaseModel):
 
 
 class SoftwarePackage(BaseModel):
+    """
+    Represents a distributable software unit (e.g., application, OS package).
+
+    A package corresponds to a deployable or installable artifact, such as an
+    application installer, system package, or container image. It identifies
+    the main software product being described, including its name, version,
+    type, and licensing information.
+    """
+
     name: str
     version: str
     uid: str | None = None
@@ -118,6 +135,14 @@ class SoftwarePackage(BaseModel):
 
 
 class SoftwareComponent(BaseModel):
+    """
+    Represents an individual component within a software package.
+
+    A component is a building block of a software package, such as a library,
+    framework, or module.
+    Components describe the internal composition of a package.
+    """
+
     version: str
     name: str
     author: str | None = None
@@ -126,6 +151,15 @@ class SoftwareComponent(BaseModel):
 
 
 class SoftwareBillOfMaterials(BaseModel):
+    """
+    Describes the composition of a software package.
+
+    A Software Bill of Materials (SBOM) provides a structured inventory of all
+    components included in a software package, along with associated metadata.
+    It is used to track dependencies, assess vulnerabilities, and improve
+    transparency in the software supply chain.
+    """
+
     package: SoftwarePackage
     software_components: list[SoftwareComponent] | None = None
     type: SBOMTypeStr | None = None
@@ -136,5 +170,5 @@ class SoftwareBillOfMaterials(BaseModel):
 
 class SoftwareOCSFModel(OCSFBaseModel):
     device: Device
-    software: Software
     sbom: SoftwareBillOfMaterials | None = None
+    enrichments: list[SoftwareEnrichmentObject] | None = None

--- a/sekoia_automation/asset_connector/models/ocsf/software.py
+++ b/sekoia_automation/asset_connector/models/ocsf/software.py
@@ -100,10 +100,72 @@ class SignatureStateStr(StrEnum):
     OTHER = "Other"
 
 
+class FingerprintAlgorithmId(IntEnum):
+    UNKNOWN = 0
+    MD5 = 1
+    SHA1 = 2
+    SHA256 = 3
+    SHA512 = 4
+    CTPH = 5
+    TLSH = 6
+    QUICKXORHASH = 7
+    SHA224 = 8
+    SHA384 = 9
+    SHA512_224 = 10
+    SHA512_256 = 11
+    SHA3_224 = 12
+    SHA3_256 = 13
+    SHA3_384 = 14
+    SHA3_512 = 15
+    XXHASH64 = 16
+    XXHASH128 = 17
+    IMPHASH = 18
+    NPF = 19
+    HASSH = 20
+    OTHER = 99
+
+
+class FingerprintAlgorithmStr(StrEnum):
+    UNKNOWN = "Unknown"
+    MD5 = "MD5"
+    SHA1 = "SHA-1"
+    SHA256 = "SHA-256"
+    SHA512 = "SHA-512"
+    CTPH = "CTPH"
+    TLSH = "TLSH"
+    QUICKXORHASH = "quickXorHash"
+    SHA224 = "SHA-224"
+    SHA384 = "SHA-384"
+    SHA512_224 = "SHA-512/224"
+    SHA512_256 = "SHA-512/256"
+    SHA3_224 = "SHA3-224"
+    SHA3_256 = "SHA3-256"
+    SHA3_384 = "SHA3-384"
+    SHA3_512 = "SHA3-512"
+    XXHASH64 = "xxHash H3 64-bit"
+    XXHASH128 = "xxHash H3 128-bit"
+    IMPHASH = "Imphash"
+    NPF = "NPF"
+    HASSH = "HASSH"
+    OTHER = "Other"
+
+
 # https://schema.ocsf.io/1.8.0/objects/fingerprint
 class Fingerprint(BaseModel):
-    algorithm_id: str | None = None
+    algorithm: FingerprintAlgorithmStr | None = None
+    algorithm_id: FingerprintAlgorithmId | None = None
+
     value: str
+
+    @model_validator(mode="after")
+    def sync_algorithm(self) -> "Fingerprint":
+        if self.algorithm_id is not None and self.algorithm is None:
+            self.algorithm = FingerprintAlgorithmStr[self.algorithm_id.name]
+
+        if self.algorithm is not None and self.algorithm_id is None:
+            self.algorithm_id = FingerprintAlgorithmId[self.algorithm.name]
+
+        return self
 
 
 # https://schema.ocsf.io/1.8.0/objects/certificate
@@ -146,7 +208,13 @@ class DigitalSignature(BaseModel):
     digest: Fingerprint | None = None
 
     @model_validator(mode="after")
-    def sync_state_fields(self) -> "DigitalSignature":
+    def sync_enums(self) -> "DigitalSignature":
+        if self.algorithm_id is not None and self.algorithm is None:
+            self.algorithm = SignatureAlgorithmStr[self.algorithm_id.name]
+
+        if self.algorithm is not None and self.algorithm_id is None:
+            self.algorithm_id = SignatureAlgorithmId[self.algorithm.name]
+
         if self.state_id is not None and self.state is None:
             self.state = SignatureStateStr[self.state_id.name]
 
@@ -165,8 +233,8 @@ class SoftwareEnrichmentObject(BaseModel):
     name, version, vendor, installation path, and usage timestamps.
     """
 
-    product_id: str | None = None
-    product_name: str | None = None
+    uid: str | None = None
+    name: str | None = None
     version: str | None = None
 
     vendor_name: str | None = None
@@ -179,26 +247,9 @@ class SoftwareEnrichmentObject(BaseModel):
 
     hashes: list[Fingerprint] | None = None
 
-    is_signed: bool | None = None
     signature: DigitalSignature | None = None
 
     binary_name: str | None = None
-
-    @model_validator(mode="after")
-    def validate_signature_consistency(self) -> "SoftwareEnrichmentObject":
-        has_signature = self.signature is not None
-
-        if self.is_signed is None:
-            self.is_signed = has_signature
-            return self
-
-        if self.is_signed and not has_signature:
-            raise ValueError("signature is required when is_signed is True")
-
-        if not self.is_signed and has_signature:
-            raise ValueError("signature must be None when is_signed is False")
-
-        return self
 
 
 class SoftwarePackage(BaseModel):
@@ -255,8 +306,19 @@ class SoftwareBillOfMaterials(BaseModel):
     uid: str | None = None
     version: str | None = None
 
+    @model_validator(mode="after")
+    def sync_type(self) -> "SoftwareBillOfMaterials":
+        if self.type_id and not self.type:
+            self.type = SBOMTypeStr[self.type_id.name]
+
+        if self.type and not self.type_id:
+            self.type_id = SBOMTypeId[self.type.name]
+
+        return self
+
 
 class SoftwareOCSFModel(OCSFBaseModel):
     device: Device
     software: SoftwareEnrichmentObject | None = None
+    # sbom corresponds to the software described in `software`
     sbom: SoftwareBillOfMaterials | None = None

--- a/sekoia_automation/asset_connector/models/ocsf/software.py
+++ b/sekoia_automation/asset_connector/models/ocsf/software.py
@@ -3,7 +3,7 @@ from enum import IntEnum, StrEnum
 from pydantic import BaseModel, model_validator
 
 from sekoia_automation.asset_connector.models.ocsf.base import OCSFBaseModel
-from sekoia_automation.asset_connector.models.ocsf.device import Device
+from sekoia_automation.asset_connector.models.ocsf.device import Device, OperatingSystem
 
 
 class SBOMTypeId(IntEnum):
@@ -17,7 +17,7 @@ class SBOMTypeId(IntEnum):
 class SBOMTypeStr(StrEnum):
     UNKNOWN = "Unknown"
     SPDX = "SPDX"
-    CYCLOEDX = "CycloDX"
+    CYCLONEDX = "CycloneDX"
     SWID = "SWID"
     OTHER = "Other"
 
@@ -52,15 +52,108 @@ class PackageTypeStr(StrEnum):
     OTHER = "Other"
 
 
+class SignatureAlgorithmId(IntEnum):
+    UNKNOWN = 0
+    DSA = 1
+    RSA = 2
+    ECDSA = 3
+    AUTHENTICODE = 4
+    OTHER = 99
+
+
+class SignatureAlgorithmStr(StrEnum):
+    UNKNOWN = "Unknown"
+    DSA = "DSA"
+    RSA = "RSA"
+    ECDSA = "ECDSA"
+    AUTHENTICODE = "Authenticode"
+    OTHER = "Other"
+
+
+class SignatureStateId(IntEnum):
+    UNKNOWN = 0
+    VALID = 1
+    EXPIRED = 2
+    REVOKED = 3
+    SUSPENDED = 4
+    PENDING = 5
+    UNTRUSTED = 6
+    DISTRUSTED = 7
+    WRONG_USAGE = 8
+    BAD = 9
+    BROKEN = 10
+    OTHER = 99
+
+
+class SignatureStateStr(StrEnum):
+    UNKNOWN = "Unknown"
+    VALID = "Valid"
+    EXPIRED = "Expired"
+    REVOKED = "Revoked"
+    SUSPENDED = "Suspended"
+    PENDING = "Pending"
+    UNTRUSTED = "Untrusted"
+    DISTRUSTED = "Distrusted"
+    WRONG_USAGE = "WrongUsage"
+    BAD = "Bad"
+    BROKEN = "Broken"
+    OTHER = "Other"
+
+
+# https://schema.ocsf.io/1.8.0/objects/fingerprint
 class Fingerprint(BaseModel):
     algorithm_id: str | None = None
     value: str
 
 
-class Signature(BaseModel):
+# https://schema.ocsf.io/1.8.0/objects/certificate
+class DigitalCertificate(BaseModel):
+    created_time: float | None = None
+    expiration_time: float | None = None
+
+    fingerprints: list[Fingerprint] | None = None
+
+    is_self_signed: bool | None = None
+
+    issuer: str
     subject: str | None = None
-    issuer: str | None = None
-    valid: bool | None = None
+
+    serial_number: str
+
+    sans: list[str] | None = None
+
+    uid: str | None = None
+    version: str | None = None
+
+
+# https://schema.ocsf.io/1.8.0/objects/digital_signature
+class DigitalSignature(BaseModel):
+    """
+    Represents a digital signature used to verify the authenticity
+    and integrity of a software.
+    """
+
+    algorithm: SignatureAlgorithmStr | None = None
+    algorithm_id: SignatureAlgorithmId | None = None
+
+    certificate: DigitalCertificate | None = None
+
+    state: SignatureStateStr | None = None
+    state_id: SignatureStateId | None = None
+
+    created_time: float | None = None
+
+    digest: Fingerprint | None = None
+
+    @model_validator(mode="after")
+    def sync_state_fields(self) -> "DigitalSignature":
+        if self.state_id is not None and self.state is None:
+            self.state = SignatureStateStr[self.state_id.name]
+
+        if self.state is not None and self.state_id is None:
+            self.state_id = SignatureStateId[self.state.name]
+
+        return self
 
 
 class SoftwareEnrichmentObject(BaseModel):
@@ -82,12 +175,12 @@ class SoftwareEnrichmentObject(BaseModel):
     install_time: float | None = None
     last_used_time: float | None = None
 
-    os: str | None = None
+    os: OperatingSystem | None = None
 
     hashes: list[Fingerprint] | None = None
 
     is_signed: bool | None = None
-    signature: Signature | None = None
+    signature: DigitalSignature | None = None
 
     binary_name: str | None = None
 
@@ -167,4 +260,3 @@ class SoftwareOCSFModel(OCSFBaseModel):
     device: Device
     software: SoftwareEnrichmentObject | None = None
     sbom: SoftwareBillOfMaterials | None = None
-    enrichments: list[SoftwareEnrichmentObject] | None = None

--- a/sekoia_automation/asset_connector/models/ocsf/software.py
+++ b/sekoia_automation/asset_connector/models/ocsf/software.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from enum import IntEnum, StrEnum
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from sekoia_automation.asset_connector.models.ocsf.base import OCSFBaseModel
 from sekoia_automation.asset_connector.models.ocsf.device import Device
@@ -87,6 +87,22 @@ class Software(BaseModel):
     signature: Signature | None = None
 
     file_name: str | None = None
+
+    @model_validator(mode="after")
+    def validate_signature_consistency(self) -> "Software":
+        has_signature = self.signature is not None
+
+        if self.is_signed is None:
+            self.is_signed = has_signature
+            return self
+
+        if self.is_signed and not has_signature:
+            raise ValueError("signature is required when is_signed is True")
+
+        if not self.is_signed and has_signature:
+            raise ValueError("signature must be None when is_signed is False")
+
+        return self
 
 
 class SoftwarePackage(BaseModel):

--- a/tests/asset_connector/test_software_model.py
+++ b/tests/asset_connector/test_software_model.py
@@ -1,21 +1,56 @@
 import pytest
 from pydantic import ValidationError
 
+from sekoia_automation.asset_connector.models.ocsf.base import (
+    Metadata,
+    Product,
+)
+from sekoia_automation.asset_connector.models.ocsf.device import (
+    Device,
+    DeviceTypeId,
+    DeviceTypeStr,
+)
 from sekoia_automation.asset_connector.models.ocsf.software import (
     Signature,
-    Software,
+    SoftwareEnrichmentObject,
+    SoftwareOCSFModel,
 )
 
 
+def _make_software_ocsf_model(**kwargs) -> SoftwareOCSFModel:
+    base_kwargs = {
+        "activity_id": 2,
+        "activity_name": "Collect",
+        "category_name": "Discovery",
+        "category_uid": 5,
+        "class_name": "Asset",
+        "class_uid": 5001,
+        "type_name": "Software Inventory Info: Collect",
+        "type_uid": 500102,
+        "time": 1633036800,
+        "metadata": Metadata(product=Product(name="Example"), version="1.0.0"),
+        "device": Device(
+            type_id=DeviceTypeId.DESKTOP,
+            type=DeviceTypeStr.DESKTOP,
+            uid="device-1",
+            hostname="host-1",
+        ),
+    }
+    base_kwargs.update(kwargs)
+    return SoftwareOCSFModel(**base_kwargs)
+
+
 def test_software_derives_is_signed_to_false_without_signature():
-    software = Software(name="example")
+    software = SoftwareEnrichmentObject(name="example")
 
     assert software.is_signed is False
     assert software.signature is None
 
 
 def test_software_derives_is_signed_to_true_with_signature_only():
-    software = Software(name="example", signature=Signature(subject="ACME"))
+    software = SoftwareEnrichmentObject(
+        name="example", signature=Signature(subject="ACME")
+    )
 
     assert software.is_signed is True
     assert software.signature is not None
@@ -23,12 +58,12 @@ def test_software_derives_is_signed_to_true_with_signature_only():
 
 def test_software_requires_signature_when_is_signed_true():
     with pytest.raises(ValidationError, match="signature is required"):
-        Software(name="example", is_signed=True)
+        SoftwareEnrichmentObject(name="example", is_signed=True)
 
 
 def test_software_rejects_signature_when_is_signed_false():
     with pytest.raises(ValidationError, match="signature must be None"):
-        Software(
+        SoftwareEnrichmentObject(
             name="example",
             is_signed=False,
             signature=Signature(subject="ACME"),
@@ -36,7 +71,7 @@ def test_software_rejects_signature_when_is_signed_false():
 
 
 def test_software_accepts_consistent_signed_state():
-    software = Software(
+    software = SoftwareEnrichmentObject(
         name="example",
         is_signed=True,
         signature=Signature(subject="ACME", issuer="CA", valid=True),
@@ -44,3 +79,29 @@ def test_software_accepts_consistent_signed_state():
 
     assert software.is_signed is True
     assert software.signature is not None
+
+
+def test_software_accepts_epoch_time_fields():
+    software = SoftwareEnrichmentObject(
+        product_name="example",
+        install_time=1_712_000_000.0,
+        last_used_time=1_712_000_123.0,
+    )
+
+    assert software.install_time == 1_712_000_000.0
+    assert software.last_used_time == 1_712_000_123.0
+
+
+def test_software_ocsf_model_allows_missing_software():
+    model = _make_software_ocsf_model()
+
+    assert model.software is None
+
+
+def test_software_ocsf_model_accepts_software_object():
+    model = _make_software_ocsf_model(
+        software=SoftwareEnrichmentObject(product_name="example", version="1.0.0")
+    )
+
+    assert model.software is not None
+    assert model.software.product_name == "example"

--- a/tests/asset_connector/test_software_model.py
+++ b/tests/asset_connector/test_software_model.py
@@ -1,6 +1,3 @@
-import pytest
-from pydantic import ValidationError
-
 from sekoia_automation.asset_connector.models.ocsf.base import (
     Metadata,
     Product,
@@ -11,9 +8,20 @@ from sekoia_automation.asset_connector.models.ocsf.device import (
     DeviceTypeStr,
 )
 from sekoia_automation.asset_connector.models.ocsf.software import (
-    Signature,
+    DigitalSignature,
+    Fingerprint,
+    FingerprintAlgorithmId,
+    FingerprintAlgorithmStr,
+    SBOMTypeId,
+    SBOMTypeStr,
+    SignatureAlgorithmId,
+    SignatureAlgorithmStr,
+    SignatureStateId,
+    SignatureStateStr,
+    SoftwareBillOfMaterials,
     SoftwareEnrichmentObject,
     SoftwareOCSFModel,
+    SoftwarePackage,
 )
 
 
@@ -40,56 +48,85 @@ def _make_software_ocsf_model(**kwargs) -> SoftwareOCSFModel:
     return SoftwareOCSFModel(**base_kwargs)
 
 
-def test_software_derives_is_signed_to_false_without_signature():
-    software = SoftwareEnrichmentObject(name="example")
-
-    assert software.is_signed is False
-    assert software.signature is None
-
-
-def test_software_derives_is_signed_to_true_with_signature_only():
-    software = SoftwareEnrichmentObject(
-        name="example", signature=Signature(subject="ACME")
-    )
-
-    assert software.is_signed is True
-    assert software.signature is not None
-
-
-def test_software_requires_signature_when_is_signed_true():
-    with pytest.raises(ValidationError, match="signature is required"):
-        SoftwareEnrichmentObject(name="example", is_signed=True)
-
-
-def test_software_rejects_signature_when_is_signed_false():
-    with pytest.raises(ValidationError, match="signature must be None"):
-        SoftwareEnrichmentObject(
-            name="example",
-            is_signed=False,
-            signature=Signature(subject="ACME"),
-        )
-
-
-def test_software_accepts_consistent_signed_state():
+def test_software_accepts_signature_object():
     software = SoftwareEnrichmentObject(
         name="example",
-        is_signed=True,
-        signature=Signature(subject="ACME", issuer="CA", valid=True),
+        signature=DigitalSignature(
+            algorithm=SignatureAlgorithmStr.RSA,
+            state=SignatureStateStr.VALID,
+        ),
     )
 
-    assert software.is_signed is True
     assert software.signature is not None
+    assert software.signature.algorithm == SignatureAlgorithmStr.RSA
+    assert software.signature.state == SignatureStateStr.VALID
 
 
 def test_software_accepts_epoch_time_fields():
     software = SoftwareEnrichmentObject(
-        product_name="example",
+        name="example",
         install_time=1_712_000_000.0,
         last_used_time=1_712_000_123.0,
     )
 
     assert software.install_time == 1_712_000_000.0
     assert software.last_used_time == 1_712_000_123.0
+
+
+def test_digital_signature_syncs_enum_from_ids():
+    signature = DigitalSignature(
+        algorithm_id=SignatureAlgorithmId.RSA,
+        state_id=SignatureStateId.VALID,
+    )
+
+    assert signature.algorithm == SignatureAlgorithmStr.RSA
+    assert signature.state == SignatureStateStr.VALID
+
+
+def test_digital_signature_syncs_ids_from_enum_values():
+    signature = DigitalSignature(
+        algorithm=SignatureAlgorithmStr.ECDSA,
+        state=SignatureStateStr.EXPIRED,
+    )
+
+    assert signature.algorithm_id == SignatureAlgorithmId.ECDSA
+    assert signature.state_id == SignatureStateId.EXPIRED
+
+
+def test_fingerprint_syncs_enum_from_id():
+    fingerprint = Fingerprint(
+        algorithm_id=FingerprintAlgorithmId.SHA256,
+        value="abc",
+    )
+
+    assert fingerprint.algorithm == FingerprintAlgorithmStr.SHA256
+
+
+def test_fingerprint_syncs_id_from_enum():
+    fingerprint = Fingerprint(
+        algorithm=FingerprintAlgorithmStr.SHA512,
+        value="abc",
+    )
+
+    assert fingerprint.algorithm_id == FingerprintAlgorithmId.SHA512
+
+
+def test_sbom_syncs_type_from_type_id():
+    sbom = SoftwareBillOfMaterials(
+        package=SoftwarePackage(name="pkg", version="1.0.0"),
+        type_id=SBOMTypeId.SPDX,
+    )
+
+    assert sbom.type == SBOMTypeStr.SPDX
+
+
+def test_sbom_syncs_type_id_from_type():
+    sbom = SoftwareBillOfMaterials(
+        package=SoftwarePackage(name="pkg", version="1.0.0"),
+        type=SBOMTypeStr.CYCLONEDX,
+    )
+
+    assert sbom.type_id == SBOMTypeId.CYCLONEDX
 
 
 def test_software_ocsf_model_allows_missing_software():
@@ -100,8 +137,8 @@ def test_software_ocsf_model_allows_missing_software():
 
 def test_software_ocsf_model_accepts_software_object():
     model = _make_software_ocsf_model(
-        software=SoftwareEnrichmentObject(product_name="example", version="1.0.0")
+        software=SoftwareEnrichmentObject(name="example", version="1.0.0")
     )
 
     assert model.software is not None
-    assert model.software.product_name == "example"
+    assert model.software.name == "example"

--- a/tests/asset_connector/test_software_model.py
+++ b/tests/asset_connector/test_software_model.py
@@ -1,0 +1,46 @@
+import pytest
+from pydantic import ValidationError
+
+from sekoia_automation.asset_connector.models.ocsf.software import (
+    Signature,
+    Software,
+)
+
+
+def test_software_derives_is_signed_to_false_without_signature():
+    software = Software(name="example")
+
+    assert software.is_signed is False
+    assert software.signature is None
+
+
+def test_software_derives_is_signed_to_true_with_signature_only():
+    software = Software(name="example", signature=Signature(subject="ACME"))
+
+    assert software.is_signed is True
+    assert software.signature is not None
+
+
+def test_software_requires_signature_when_is_signed_true():
+    with pytest.raises(ValidationError, match="signature is required"):
+        Software(name="example", is_signed=True)
+
+
+def test_software_rejects_signature_when_is_signed_false():
+    with pytest.raises(ValidationError, match="signature must be None"):
+        Software(
+            name="example",
+            is_signed=False,
+            signature=Signature(subject="ACME"),
+        )
+
+
+def test_software_accepts_consistent_signed_state():
+    software = Software(
+        name="example",
+        is_signed=True,
+        signature=Signature(subject="ACME", issuer="CA", valid=True),
+    )
+
+    assert software.is_signed is True
+    assert software.signature is not None


### PR DESCRIPTION
This PR adds software-related information to the OCSF asset connector models.

## Summary by Sourcery

Extend OCSF asset connector models to represent installed software details on devices.

New Features:
- Introduce models for software file hashes and code signatures in the OCSF asset connector schema.
- Add a Software model capturing identity, vendor, platform, installation metadata, and signing status for software assets.
- Include software information in the SoftwareOCSFModel alongside existing device and SBOM data.