### PR TITLE
feat(ocsf): add architecture and last_user_name to SoftwareEnrichmentObject

### DIFF
--- a/sekoia_automation/asset_connector/models/ocsf/software.py
+++ b/sekoia_automation/asset_connector/models/ocsf/software.py
@@ -250,6 +250,8 @@ class SoftwareEnrichmentObject(BaseModel):
     signature: DigitalSignature | None = None
 
     binary_name: str | None = None
+    architecture: str | None = None
+    last_user_name: str | None = None
 
 
 class SoftwarePackage(BaseModel):

--- a/tests/asset_connector/test_software_model.py
+++ b/tests/asset_connector/test_software_model.py
@@ -142,3 +142,22 @@ def test_software_ocsf_model_accepts_software_object():
 
     assert model.software is not None
     assert model.software.name == "example"
+
+
+def test_software_accepts_architecture():
+    software = SoftwareEnrichmentObject(name="example", architecture="x86_64")
+
+    assert software.architecture == "x86_64"
+
+
+def test_software_accepts_last_user_name():
+    software = SoftwareEnrichmentObject(name="example", last_user_name="jdoe")
+
+    assert software.last_user_name == "jdoe"
+
+
+def test_software_architecture_and_last_user_name_are_optional():
+    software = SoftwareEnrichmentObject(name="example")
+
+    assert software.architecture is None
+    assert software.last_user_name is None


### PR DESCRIPTION
Adds `architecture` field (optional `str`) to `SoftwareEnrichmentObject` to capture the CPU architecture of the software (e.g. `x86_64`, `arm64`).                                    
                                                                                                                                                                                      
Adds `last_user_name` field (optional `str`) to `SoftwareEnrichmentObject` to capture the name of the last user who ran the software.                                                 
                                                                                                                                                                                      
Both fields are optional and default to `None`.

## Summary by Sourcery

Extend the software enrichment model to capture additional metadata about software executions.

New Features:
- Add optional architecture field to SoftwareEnrichmentObject to store the software CPU architecture.
- Add optional last_user_name field to SoftwareEnrichmentObject to store the name of the last user who ran the software.

Tests:
- Add tests verifying SoftwareEnrichmentObject accepts architecture and last_user_name and that both fields default to None when omitted.