### PR TITLE
SDK: release 1.22.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.22.6 - 2026-05-12
+
 ### Added
 
 - Introduce a new `SekoiaAutomationBaseModel` (preconfigured Pydantic’s `BaseModel`) to avoid int-to-str issues.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sekoia-automation-sdk"
-version = "1.22.5"
+version = "1.22.6"
 description = "SDK to create Sekoia.io playbook modules"
 authors = [{ name = "Sekoia.io" }]
 requires-python = ">=3.11,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -2243,7 +2243,7 @@ wheels = [
 
 [[package]]
 name = "sekoia-automation-sdk"
-version = "1.22.5"
+version = "1.22.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiocsv" },


### PR DESCRIPTION
## Summary by Sourcery

Release SDK version 1.22.6 and document the new release.

New Features:
- Document the introduction of SekoiaAutomationBaseModel in the changelog.

Build:
- Bump the sekoia-automation-sdk project version to 1.22.6 in pyproject metadata.