### PR TITLE
SDK: release 1.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 1.22.6 - 2026-05-12
+## 1.23.0 - 2026-05-12
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sekoia-automation-sdk"
-version = "1.22.6"
+version = "1.23.0"
 description = "SDK to create Sekoia.io playbook modules"
 authors = [{ name = "Sekoia.io" }]
 requires-python = ">=3.11,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -2243,7 +2243,7 @@ wheels = [
 
 [[package]]
 name = "sekoia-automation-sdk"
-version = "1.22.6"
+version = "1.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiocsv" },


### PR DESCRIPTION
Due to changes related to Pydantic, fix the version number of the new release

## Summary by Sourcery

Bump the SDK to version 1.23.0 and align project metadata and changelog with the new release.

Build:
- Update project version in pyproject configuration to 1.23.0.

Documentation:
- Update changelog entry to reflect the 1.23.0 release version.