### PR TITLE
fix: Raise exception on error when retrieving secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.23.1 - 2026-05-26
+
+### Fixed
+
+- Raise exception on error when retrieving secrets
+
 ## 1.23.0 - 2026-05-12
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sekoia-automation-sdk"
-version = "1.23.0"
+version = "1.23.1"
 description = "SDK to create Sekoia.io playbook modules"
 authors = [{ name = "Sekoia.io" }]
 requires-python = ">=3.11,<4"

--- a/sekoia_automation/trigger.py
+++ b/sekoia_automation/trigger.py
@@ -115,7 +115,7 @@ class Trigger(ModuleItem):
                 secrets = response.json()["value"]
             except HTTPError as exception:
                 self._log_request_error(exception)
-                raise exception
+                raise
         return secrets
 
     def stop(self, *args, **kwargs) -> None:  # noqa: ARG002

--- a/sekoia_automation/trigger.py
+++ b/sekoia_automation/trigger.py
@@ -115,6 +115,7 @@ class Trigger(ModuleItem):
                 secrets = response.json()["value"]
             except HTTPError as exception:
                 self._log_request_error(exception)
+                raise exception
         return secrets
 
     def stop(self, *args, **kwargs) -> None:  # noqa: ARG002

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -516,6 +516,26 @@ def test_get_secrets(_, __, ___):
         trigger.stop()
 
 
+@patch.object(Module, "has_secrets", return_value=True)
+def test_get_secrets_http_error_retries(_, mocked_trigger_logs):
+    trigger = DummyTrigger()
+    # Avoid long waits during the test
+    trigger._get_secrets_from_server.retry.wait = wait_none()
+    trigger._send_logs_to_api.retry.wait = wait_none()
+
+    mocked_trigger_logs.register_uri(
+        "GET",
+        "http://sekoia-playbooks/secrets",
+        status_code=500,
+    )
+
+    with pytest.raises(requests.HTTPError):
+        trigger._get_secrets_from_server()
+
+    get_calls = [r for r in mocked_trigger_logs.request_history if r.method == "GET"]
+    assert len(get_calls) == 10
+
+
 @pytest.fixture()
 def monitored_trigger():
     trigger = DummyTrigger()

--- a/uv.lock
+++ b/uv.lock
@@ -2243,7 +2243,7 @@ wheels = [
 
 [[package]]
 name = "sekoia-automation-sdk"
-version = "1.23.0"
+version = "1.23.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiocsv" },


### PR DESCRIPTION
Not raising an  error prevents the http call from being retried and return an empty dict as secrets.

## Summary by Sourcery

Raise an exception when secret retrieval fails and bump the SDK patch version.

Bug Fixes:
- Ensure an exception is raised on HTTP errors when retrieving secrets so failed calls can be retried instead of returning empty secrets.

Chores:
- Update changelog and project version for the 1.23.1 patch release.