### PR TITLE
Make a longer retry for 422 error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve `GenericAPIAction` HTTP error messages by including HTTP status code and retry information (attempt count and retry count) for both immediate client errors and final retry failures
 
+### Changed
+
+ - Use a longer wait for 422 errors, while trying to push events
+
 ### Fixed
 
 - Fix test suite compatibility with Python 3.14 by patching `aioresponses` usage in tests and updating a CLI exception assertion to `typer.Exit`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
- - Use a longer wait for 422 errors, while trying to push events
+ - Use a longer wait for INTAKE_KEY_ERROR, while trying to push events
 
 ### Fixed
 

--- a/sekoia_automation/aio/connector.py
+++ b/sekoia_automation/aio/connector.py
@@ -17,6 +17,7 @@ from sekoia_automation.connector import (
     Connector,
     DefaultConnectorConfiguration,
     EventType,
+    SendEventsChunkError,
 )
 from sekoia_automation.module import Module
 
@@ -106,14 +107,14 @@ class AsyncConnector(Connector, ABC):
                 ) as response:
                     if response.status >= 300:
                         error = await response.text()
-                        error_message = (
-                            f"Chunk {chunk_index} error ({response.status}) "
-                            f"on attempt {attempt.retry_state.attempt_number}: {error}"
+
+                        exception = SendEventsChunkError(
+                            chunk_index=chunk_index,
+                            attempt_number=attempt.retry_state.attempt_number,
+                            status_code=response.status,
+                            response_body=error,
                         )
-                        exception = RuntimeError(error_message)
-
                         self.log_exception(exception)
-
                         raise exception
 
                     result = await response.json()

--- a/sekoia_automation/connector/__init__.py
+++ b/sekoia_automation/connector/__init__.py
@@ -15,7 +15,13 @@ import requests
 import sentry_sdk
 from pydantic import BaseModel
 from requests import Response
-from tenacity import Retrying, stop_after_delay, wait_exponential
+from tenacity import (
+    RetryCallState,
+    Retrying,
+    stop_after_delay,
+    wait_exponential,
+    wait_fixed,
+)
 
 from sekoia_automation.connector.metrics import MetricsMixin
 from sekoia_automation.constants import CHUNK_BYTES_MAX_SIZE, EVENT_BYTES_MAX_SIZE
@@ -33,6 +39,26 @@ EventType: TypeAlias = dict[str, Any] | str | BaseModel
 class DefaultConnectorConfiguration(BaseModel):
     intake_server: str | None = None
     intake_key: str
+
+
+class SendEventsChunkError(Exception):
+    def __init__(
+        self,
+        status_code: int,
+        response_body: str,
+        chunk_index: int,
+        attempt_number: int,
+    ):
+        self.status_code = status_code
+        self.response_body = response_body
+        self.chunk_index = chunk_index
+        self.attempt_number = attempt_number
+
+    def __str__(self):
+        return (
+            f"Chunk {self.chunk_index} error ({self.status_code}) "
+            f"on attempt {self.attempt_number}: {self.response_body}"
+        )
 
 
 class Connector(Trigger, MetricsMixin, ABC):
@@ -95,10 +121,23 @@ class Connector(Trigger, MetricsMixin, ABC):
         super().stop(*args, **kwargs)
         self._executor.shutdown(wait=True)
 
+    def _wait_by_error_type(self, retry_state: RetryCallState) -> float:
+        exception = retry_state.outcome.exception() if retry_state.outcome else None
+        if isinstance(exception, SendEventsChunkError):
+            response_code: int = exception.status_code
+            response_text: str = exception.response_body
+            if response_code == 422 and "INTAKE_KEY_ERROR" in response_text:
+                # If we have an INTAKE_KEY_ERROR, then most probably it's
+                # just not ready. We need to wait a bit more to make sure
+                # it's ready to accept events.
+                return wait_fixed(wait=300)(retry_state=retry_state)
+
+        return wait_exponential(multiplier=1, min=1, max=10)(retry_state=retry_state)
+
     def _retry(self):
         return Retrying(
             stop=stop_after_delay(3600),  # 1 hour without being able to send events
-            wait=wait_exponential(multiplier=1, min=1, max=10),
+            wait=self._wait_by_error_type,
             reraise=True,
         )
 
@@ -149,7 +188,17 @@ class Connector(Trigger, MetricsMixin, ABC):
                         json=request_body,
                         timeout=30,
                     )
-                    res.raise_for_status()
+                    try:
+                        res.raise_for_status()
+
+                    except requests.RequestException:
+                        raise SendEventsChunkError(
+                            status_code=res.status_code,
+                            response_body=res.text,
+                            chunk_index=chunk_index,
+                            attempt_number=attempt.retry_state.attempt_number,
+                        )
+
             collect_ids[chunk_index] = res.json().get("event_ids", [])
         except Exception as ex:
             message = f"Failed to forward {len(chunk)} events"

--- a/tests/aio/test_connector.py
+++ b/tests/aio/test_connector.py
@@ -9,9 +9,10 @@ import pytest
 from aiolimiter import AsyncLimiter
 from aioresponses import aioresponses
 from faker import Faker
-from tenacity import Retrying, stop_after_attempt, wait_none
+from tenacity import Retrying, stop_after_attempt
 
 from sekoia_automation.aio.connector import AsyncConnector
+from sekoia_automation.connector import SendEventsChunkError
 
 
 class DummyAsyncConnector(AsyncConnector):
@@ -46,7 +47,9 @@ def async_connector(storage, mocked_trigger_logs, faker: Faker):
         async_connector.log = Mock()
         async_connector.log_exception = Mock()
         async_connector._retry = lambda: Retrying(
-            reraise=True, stop=stop_after_attempt(5), wait=wait_none()
+            reraise=True,
+            stop=stop_after_attempt(5),
+            wait=async_connector._wait_by_error_type,
         )
 
         yield async_connector
@@ -209,7 +212,7 @@ async def test_async_connector_raise_error(
             await async_connector.push_data_to_intakes(events)
 
         except Exception as e:
-            assert isinstance(e, RuntimeError)
+            assert isinstance(e, SendEventsChunkError)
             assert str(e) == expected_error
 
 
@@ -318,7 +321,7 @@ async def test_async_push_events_422_retries_and_succeeds_second_attempt(
     with (
         aioresponses() as mocked_responses,
         patch("sekoia_automation.connector.CHUNK_BYTES_MAX_SIZE", 128),
-        patch("asyncio.sleep") as mock_sleep,
+        patch("time.sleep") as mock_sleep,
     ):
         # First attempt: 422
         mocked_responses.post(
@@ -351,7 +354,7 @@ async def test_async_push_events_422_retries_and_succeeds_third_attempt(
     with (
         aioresponses() as mocked_responses,
         patch("sekoia_automation.connector.CHUNK_BYTES_MAX_SIZE", 128),
-        patch("asyncio.sleep") as mock_sleep,
+        patch("time.sleep") as mock_sleep,
     ):
         # First and second attempts: 422
         mocked_responses.post(request_url, status=422, body="Not ready")
@@ -381,13 +384,13 @@ async def test_async_push_events_422_fails_after_max_retries(
     with (
         aioresponses() as mocked_responses,
         patch("sekoia_automation.connector.CHUNK_BYTES_MAX_SIZE", 128),
-        patch("asyncio.sleep") as mock_sleep,
+        patch("time.sleep") as mock_sleep,
     ):
         # Return 422 for all 4 attempts (initial + 3 retries)
         for _ in range(5):
             mocked_responses.post(request_url, status=422, body="Not ready")
 
-        with pytest.raises(RuntimeError) as exc_info:
+        with pytest.raises(SendEventsChunkError) as exc_info:
             await async_connector.push_data_to_intakes(events)
 
     # Verify error message
@@ -412,7 +415,7 @@ async def test_async_push_events_other_4xx_fails_immediately(
         with (
             aioresponses() as mocked_responses,
             patch("sekoia_automation.connector.CHUNK_BYTES_MAX_SIZE", 128),
-            patch("asyncio.sleep") as mock_sleep,
+            patch("time.sleep") as mock_sleep,
         ):
             for _ in range(5):
                 mocked_responses.post(
@@ -421,7 +424,7 @@ async def test_async_push_events_other_4xx_fails_immediately(
                     body="Client error",
                 )
 
-            with pytest.raises(RuntimeError) as exc_info:
+            with pytest.raises(SendEventsChunkError) as exc_info:
                 await async_connector.push_data_to_intakes(events)
 
         assert f"Chunk 0 error ({status_code}) on attempt 5: Client error" in str(
@@ -454,7 +457,7 @@ async def test_async_push_events_5xx_raises_exception(
             body="Service unavailable",
         )
 
-        with pytest.raises(RuntimeError) as exc_info:
+        with pytest.raises(SendEventsChunkError) as exc_info:
             await async_connector.push_data_to_intakes(events)
 
     # Verify error message contains status code

--- a/tests/aio/test_connector.py
+++ b/tests/aio/test_connector.py
@@ -464,3 +464,27 @@ async def test_async_push_events_5xx_raises_exception(
     assert "Chunk 0 error (503) on attempt 1: Service unavailable" in str(
         exc_info.value
     )
+
+@pytest.mark.asyncio
+async def test_push_events_with_intake_key_error(async_connector: DummyAsyncConnector, faker: Faker):
+    url = urljoin(async_connector.configuration.intake_server, "batch")
+    events = [faker.word() for _ in range(2)]
+
+    with aioresponses() as mocked_responses, patch("time.sleep") as mock_sleep:
+        mocked_responses.post(
+            url,
+            status=422, body="...INTAKE_KEY_ERROR..."
+        )
+        mocked_responses.post(
+            url,
+            status=422, body="...INTAKE_KEY_ERROR..."
+        )
+        mocked_responses.post(
+            url,
+            status=200, payload={"event_ids": events}
+        )
+        await async_connector.push_data_to_intakes(events)
+
+    assert mock_sleep.call_count == 2
+    assert mock_sleep.call_args_list[0][0][0] == 300
+    assert mock_sleep.call_args_list[1][0][0] == 300

--- a/tests/connectors/test_connector.py
+++ b/tests/connectors/test_connector.py
@@ -47,7 +47,9 @@ def test_connector(storage, mocked_trigger_logs):
         test_connector.log = Mock()
         test_connector.log_exception = Mock()
         test_connector._retry = lambda: Retrying(
-            reraise=True, stop=stop_after_attempt(3), wait=wait_none()
+            reraise=True,
+            stop=stop_after_attempt(3),
+            wait=test_connector._wait_by_error_type,
         )
 
         yield test_connector
@@ -345,8 +347,9 @@ def test_push_events_422_retries_and_succeeds_second_attempt(
         result = test_connector.push_events_to_intakes(EVENTS)
 
     assert result == ["001", "002"]
-    # Verify exponential backoff: slept 0 second before 2nd attempt because of wait_none
-    mock_sleep.assert_called_once_with(0.0)
+    # Verify exponential backoff: slept 1 second before the 2nd
+    # attempt because of wait_exponential
+    mock_sleep.assert_called_once_with(1.0)
 
 
 def test_push_events_422_retries_and_succeeds_third_attempt(
@@ -367,10 +370,10 @@ def test_push_events_422_retries_and_succeeds_third_attempt(
         result = test_connector.push_events_to_intakes(EVENTS)
 
     assert result == ["001", "002"]
-    # Verify exponential backoff: 0s, then 0s because of wait_none
+    # Verify exponential backoff: 1s, then 2s because of wait_exponential
     assert mock_sleep.call_count == 2
-    assert mock_sleep.call_args_list[0][0][0] == 0.0
-    assert mock_sleep.call_args_list[1][0][0] == 0.0
+    assert mock_sleep.call_args_list[0][0][0] == 1.0
+    assert mock_sleep.call_args_list[1][0][0] == 2.0
 
 
 def test_push_events_422_fails_after_max_retries(test_connector, mocked_trigger_logs):
@@ -392,10 +395,10 @@ def test_push_events_422_fails_after_max_retries(test_connector, mocked_trigger_
 
     # Should return empty list after all retries fail
     assert result == []
-    # Verify exponential backoff: 0s, 0s, 0s because of wait_none
+    # Verify exponential backoff: 0s, 1s, 2s because of wait_exponential
     assert mock_sleep.call_count == 2
-    assert mock_sleep.call_args_list[0][0][0] == 0.0
-    assert mock_sleep.call_args_list[1][0][0] == 0.0
+    assert mock_sleep.call_args_list[0][0][0] == 1.0
+    assert mock_sleep.call_args_list[1][0][0] == 2.0
 
     test_connector.log_exception.assert_called_once()
 
@@ -417,6 +420,7 @@ def test_push_events_other_4xx_fails_immediately(test_connector, mocked_trigger_
         mock_sleep.call_count = 2
         # Error should be logged
         test_connector.log_exception.assert_called_once()
+        assert mock_sleep.call_args_list[0][0][0] == 1.0
 
 
 def test_push_events_5xx_uses_standard_retry(test_connector, mocked_trigger_logs):
@@ -430,10 +434,8 @@ def test_push_events_5xx_uses_standard_retry(test_connector, mocked_trigger_logs
         ],
     )
 
-    # Use standard retry with limited attempts for test
-    test_connector._retry = lambda: Retrying(
-        reraise=True, stop=stop_after_attempt(5), wait=wait_none()
-    )
+    with patch("time.sleep") as mock_sleep:
+        result = test_connector.push_events_to_intakes(EVENTS)
 
-    result = test_connector.push_events_to_intakes(EVENTS)
     assert result == ["001", "002"]
+    assert mock_sleep.call_args_list[0][0][0] == 1.0

--- a/tests/connectors/test_connector.py
+++ b/tests/connectors/test_connector.py
@@ -439,3 +439,25 @@ def test_push_events_5xx_uses_standard_retry(test_connector, mocked_trigger_logs
 
     assert result == ["001", "002"]
     assert mock_sleep.call_args_list[0][0][0] == 1.0
+
+
+def test_push_events_with_intake_key_error(test_connector, mocked_trigger_logs):
+    url = "https://intake.sekoia.io/batch"
+    mocked_trigger_logs.post(
+        url,
+        [
+            {"status_code": 422, "text": "...INTAKE_KEY_ERROR..."},
+            {"status_code": 422, "text": "...INTAKE_KEY_ERROR..."},
+            {"json": {"event_ids": ["001", "002"]}, "status_code": 200},
+        ],
+    )
+
+    with patch("time.sleep") as mock_sleep:
+        result = test_connector.push_events_to_intakes(EVENTS)
+
+    assert result == ["001", "002"]
+
+    # Verify fixed timeout of 300s
+    assert mock_sleep.call_count == 2
+    assert mock_sleep.call_args_list[0][0][0] == 300
+    assert mock_sleep.call_args_list[1][0][0] == 300


### PR DESCRIPTION
https://github.com/SekoiaLab/platform/issues/85007

## Summary by Sourcery

Adjust connector retry behavior to use error-type-specific waiting, particularly extending wait time for 422 responses when pushing events.

Enhancements:
- Introduce a helper that selects fixed or exponential wait times based on the HTTP error type in connector retries.

Documentation:
- Document the longer wait behavior for 422 errors when pushing events in the changelog.

Tests:
- Update connector retry tests to validate the new fixed wait time for 422 errors and the standard wait time for other 4xx/5xx errors.