### PR TITLE
Fix: EntraId Job Title Department (1726)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dmypy.json
 .vscode/
 
 .devcontainer/*
+
+.claude
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [Unreleased] - 2026-07-07
+
+### Added
+
+- Add OCSF `ldap_person` object (`job_title`, `department`, `employee_uid`, `given_name`, `surname`, `office_location`) and expose it as `User.ldap_person` on the user inventory model, giving asset connectors a structured, canonical home for identity attributes
+
 ## [Unreleased] - 2026-06-16
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sekoia-automation-sdk"
-version = "1.23.1"
+version = "1.24.0"
 description = "SDK to create Sekoia.io playbook modules"
 authors = [{ name = "Sekoia.io" }]
 requires-python = ">=3.11,<4"

--- a/sekoia_automation/asset_connector/models/ocsf/user.py
+++ b/sekoia_automation/asset_connector/models/ocsf/user.py
@@ -104,6 +104,21 @@ class Account(BaseModel):
     uid: str | None = None
 
 
+class LdapPerson(BaseModel):
+    """
+    LdapPerson model represents the LDAP/directory attributes of a person.
+    Canonical OCSF home for identity attributes such as job title and department.
+    https://schema.ocsf.io/1.6.0/objects/ldap_person
+    """
+
+    job_title: str | None = None
+    department: str | None = None
+    employee_uid: str | None = None
+    given_name: str | None = None
+    surname: str | None = None
+    office_location: str | None = None
+
+
 class User(BaseModel):
     has_mfa: bool | None = None
     name: str
@@ -122,6 +137,7 @@ class User(BaseModel):
     type: UserTypeStr | None = None
     uid_alt: str | None = None
     org: Organization | None = None
+    ldap_person: LdapPerson | None = None
 
 
 class UserOCSFModel(OCSFBaseModel):

--- a/tests/asset_connector/test_user_model.py
+++ b/tests/asset_connector/test_user_model.py
@@ -1,0 +1,56 @@
+from sekoia_automation.asset_connector.models.ocsf.user import (
+    LdapPerson,
+    User,
+)
+
+
+def test_user_accepts_ldap_person():
+    user = User(
+        name="john.doe@example.com",
+        uid="uid-1",
+        ldap_person=LdapPerson(
+            job_title="Managing Consultant, Incident Response",
+            department="Incident Response",
+        ),
+    )
+
+    assert user.ldap_person is not None
+    assert user.ldap_person.job_title == "Managing Consultant, Incident Response"
+    assert user.ldap_person.department == "Incident Response"
+
+
+def test_user_ldap_person_is_optional():
+    user = User(name="jane.doe@example.com", uid="uid-2")
+
+    assert user.ldap_person is None
+
+
+def test_ldap_person_serializes_only_set_fields():
+    user = User(
+        name="john.doe@example.com",
+        uid="uid-3",
+        ldap_person=LdapPerson(job_title="SOC Analyst", department="Security"),
+    )
+
+    dumped = user.model_dump(exclude_none=True)
+
+    assert dumped["ldap_person"] == {
+        "job_title": "SOC Analyst",
+        "department": "Security",
+    }
+
+
+def test_ldap_person_accepts_extended_fields():
+    ldap_person = LdapPerson(
+        job_title="SOC Analyst",
+        department="Security",
+        employee_uid="EMP123",
+        given_name="John",
+        surname="Doe",
+        office_location="New York, NY",
+    )
+
+    assert ldap_person.employee_uid == "EMP123"
+    assert ldap_person.given_name == "John"
+    assert ldap_person.surname == "Doe"
+    assert ldap_person.office_location == "New York, NY"

--- a/uv.lock
+++ b/uv.lock
@@ -2298,7 +2298,7 @@ wheels = [
 
 [[package]]
 name = "sekoia-automation-sdk"
-version = "1.23.1"
+version = "1.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiocsv" },


### PR DESCRIPTION
Relates to [1726](https://github.com/SekoiaLab/integration/issues/1726)

## Summary by Sourcery

Introduce an OCSF-compliant LDAP person object and expose it on the user inventory model to provide a structured home for identity attributes such as job title and department.

New Features:
- Add an LdapPerson model capturing LDAP/directory attributes like job title, department, employee UID, given name, surname, and office location.
- Expose the ldap_person field on the User model to associate structured identity attributes with users.

Build:
- Bump the SDK version from 1.23.1 to 1.24.0 to reflect the new user identity modeling capability.

Documentation:
- Update the changelog to document the new ldap_person object and its exposure on the User model.

Tests:
- Add unit tests to validate that User accepts an optional ldap_person, that ldap_person serializes only populated fields, and that extended LDAP attributes are handled correctly.