### PR TITLE
Fix: Eset Asset Connector Fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Always log JSON-serializable content when request body is not JSON
 - Handle HTTP 429 rate limiting on the asset connector push endpoint by pausing for the `Retry-After` duration (default: 1h, configurable).
 - Refetch assets when a field mapping change is detected
+- Add `is_fix_available` to the OCSF `VulnerabilityDetails` object and `risk_score`/`risk_level`/`risk_level_id`/`risk_details` to the `VulnerabilityOCSFModel` finding class (OCSF 1.5.0 vulnerability_finding)
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sekoia-automation-sdk"
-version = "1.24.0"
+version = "1.23.1"
 description = "SDK to create Sekoia.io playbook modules"
 authors = [{ name = "Sekoia.io" }]
 requires-python = ">=3.11,<4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sekoia-automation-sdk"
-version = "1.23.1"
+version = "1.24.0"
 description = "SDK to create Sekoia.io playbook modules"
 authors = [{ name = "Sekoia.io" }]
 requires-python = ">=3.11,<4"

--- a/sekoia_automation/asset_connector/models/ocsf/vulnerability.py
+++ b/sekoia_automation/asset_connector/models/ocsf/vulnerability.py
@@ -4,7 +4,10 @@ from pydantic import BaseModel
 
 from sekoia_automation.asset_connector.models.ocsf.base import OCSFBaseModel, Product
 from sekoia_automation.asset_connector.models.ocsf.device import Device
-from sekoia_automation.asset_connector.models.ocsf.risk_level import RiskLevelId, RiskLevelStr
+from sekoia_automation.asset_connector.models.ocsf.risk_level import (
+    RiskLevelId,
+    RiskLevelStr,
+)
 
 
 class KillChainPhase(StrEnum):

--- a/sekoia_automation/asset_connector/models/ocsf/vulnerability.py
+++ b/sekoia_automation/asset_connector/models/ocsf/vulnerability.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 
 from sekoia_automation.asset_connector.models.ocsf.base import OCSFBaseModel, Product
 from sekoia_automation.asset_connector.models.ocsf.device import Device
+from sekoia_automation.asset_connector.models.ocsf.risk_level import RiskLevelId, RiskLevelStr
 
 
 class KillChainPhase(StrEnum):
@@ -93,6 +94,7 @@ class VulnerabilityDetails(BaseModel):
     cve: CVE | None = None
     severity: str | None = None
     vendor_name: str | None = None
+    is_fix_available: bool | None = None
 
 
 # https://schema.ocsf.io/1.5.0/classes/vulnerability_finding
@@ -103,3 +105,7 @@ class VulnerabilityOCSFModel(OCSFBaseModel):
     confidence: str | None = None
     confidence_id: int | None = None
     confidence_score: int | None = None
+    risk_score: int | None = None
+    risk_level: RiskLevelStr | None = None
+    risk_level_id: RiskLevelId | None = None
+    risk_details: str | None = None


### PR DESCRIPTION
Relates to this PR https://github.com/SEKOIA-IO/automation-library/pull/2857
And to this task [1741](https://github.com/SekoiaLab/integration/issues/1741)

## Summary by Sourcery

Extend OCSF vulnerability models to capture fix availability and risk metadata for asset connector findings.

New Features:
- Add an `is_fix_available` flag to the OCSF `VulnerabilityDetails` object to expose remediation availability.
- Add `risk_score`, `risk_level`, `risk_level_id`, and `risk_details` fields to the OCSF vulnerability finding model to represent risk assessment data.

Build:
- Bump SDK version from 1.23.1 to 1.24.0.

Documentation:
- Document the new vulnerability fix and risk fields in the changelog.