### PR TITLE
ci: Publish package on PyPI as trusted publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,8 +7,11 @@ permissions: {}
 
 jobs:
   build-n-publish:
+    environment:
+      name: pypi
     permissions:
       contents: read  # for actions/checkout to fetch code
+      id-token: write
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     runs-on: ubuntu-latest
     steps:
@@ -29,7 +32,5 @@ jobs:
         run: uv build
 
       - name: Publish SDK 📦 to PyPI
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |
           uv publish


### PR DESCRIPTION
Make GitHub Actions CI to use PyPI’s Trusting publishing feature.