### PR TITLE
Fix: Possible Fix For Open Connections (1826)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Pace every run loop with an exponential backoff after a failed cycle. `Trigger.execute`, `Connector.run`, `AsyncConnector.async_run`, `AssetConnector.run` and `AsyncAssetConnector.async_run` restarted a failed cycle with no delay at all, so a permanent failure (invalid credentials, unreachable endpoint) turned into a busy loop that saturated a CPU and hammered the remote API. The two loops that did pause relied on `Connector.frequency`, which defaults to `0`, so the pause never happened.
+
+### Added
+
+- `sekoia_automation.backoff`, exposing `error_backoff` and `async_error_backoff`: thin `tenacity` factories used by the run loops. The delay grows across consecutive failures, is capped by `Trigger.ERROR_BACKOFF_MAX` (5 minutes) and spread by `Trigger.ERROR_BACKOFF_JITTER` (30 seconds); both are overridable per class. The pause waits on the stop event, so `SIGTERM` is still honoured immediately.
+
+### Changed
+
+- `Trigger._execute_once` now returns whether `run` completed without raising
+
 ## 1.24.0 - 2026-07-30
 
 ### Added

--- a/sekoia_automation/aio/connector.py
+++ b/sekoia_automation/aio/connector.py
@@ -221,17 +221,19 @@ class AsyncConnector(Connector, ABC):
     # Put infinite arg only to have testing easier
     async def async_run(self) -> None:  # pragma: no cover
         """Runs Connector."""
-        while self.running:
-            try:
-                await self.async_next_run()
-            except Exception as e:
-                self.log_exception(
-                    e,
-                    message=f"Error while running connector {self.connector_name}",
-                )
+        log_backoff = self._log_backoff(
+            f"Error while running connector {self.connector_name}"
+        )
 
-                if self.frequency:
-                    await asyncio.sleep(self.frequency)
+        while self.running:
+            # New controller per iteration, so the delay resets on success.
+            # `self.frequency` is not usable as a pause here: it defaults to 0.
+            async for attempt in self._async_error_backoff(log_backoff):
+                with attempt:
+                    if not self.running:
+                        break
+
+                    await self.async_next_run()
 
         if self._session:
             await self._session.close()

--- a/sekoia_automation/asset_connector/async_connector.py
+++ b/sekoia_automation/asset_connector/async_connector.py
@@ -544,27 +544,35 @@ class AsyncAssetConnector(Trigger):
         """
         Async main loop that continuously fetches and pushes assets.
         """
+        log_backoff = self._log_backoff(
+            f"Error while running asset connector {self.connector_name}"
+        )
+
         try:
             while self.running:
-                try:
-                    await self.asset_fetch_cycle()
-                except AssetConnectorRateLimitError as e:
-                    self.log(
-                        message=f"Rate limit hit, pausing connector "
-                        f"for {e.retry_after} seconds",
-                        level="warning",
-                    )
-                    # Wait in a worker thread with the timeout passed to
-                    # Event.wait itself: the thread returns cleanly after
-                    # retry_after (or immediately when stop() is signalled),
-                    # so no thread is leaked per pause.
-                    await asyncio.to_thread(self._stop_event.wait, e.retry_after)
-                except Exception as e:
-                    self.log_exception(
-                        e,
-                        message=f"Error while running asset connector "
-                        f"{self.connector_name}",
-                    )
+                # New controller per iteration, so the delay resets on success.
+                async for attempt in self._async_error_backoff(log_backoff):
+                    with attempt:
+                        if not self.running:
+                            break
+
+                        try:
+                            await self.asset_fetch_cycle()
+                        except AssetConnectorRateLimitError as e:
+                            # Not a failure: handled here so it does not stack
+                            # with the error backoff.
+                            self.log(
+                                message=f"Rate limit hit, pausing connector "
+                                f"for {e.retry_after} seconds",
+                                level="warning",
+                            )
+                            # Wait in a worker thread with the timeout passed to
+                            # Event.wait itself: the thread returns cleanly after
+                            # retry_after (or immediately when stop() is signalled),
+                            # so no thread is leaked per pause.
+                            await asyncio.to_thread(
+                                self._stop_event.wait, e.retry_after
+                            )
         finally:
             # Clean up session on exit
             if self._session:

--- a/sekoia_automation/asset_connector/connector.py
+++ b/sekoia_automation/asset_connector/connector.py
@@ -477,19 +477,25 @@ class AssetConnector(Trigger):
             time.sleep(delta_sleep)
 
     def run(self) -> None:
+        log_backoff = self._log_backoff(
+            f"Error while running asset connector {self.connector_name}"
+        )
+
         while self.running:
-            try:
-                self.asset_fetch_cycle()
-            except AssetConnectorRateLimitError as e:
-                self.log(
-                    message=f"Rate limit hit, pausing connector "
-                    f"for {e.retry_after} seconds",
-                    level="warning",
-                )
-                self._stop_event.wait(e.retry_after)
-            except Exception as e:
-                self.log_exception(
-                    e,
-                    message=f"Error while running asset connector "
-                    f"{self.connector_name}",
-                )
+            # New controller per iteration, so the delay resets on success.
+            for attempt in self._error_backoff(log_backoff):
+                with attempt:
+                    if not self.running:
+                        break
+
+                    try:
+                        self.asset_fetch_cycle()
+                    except AssetConnectorRateLimitError as e:
+                        # Not a failure: handled here so it does not stack with
+                        # the error backoff.
+                        self.log(
+                            message=f"Rate limit hit, pausing connector "
+                            f"for {e.retry_after} seconds",
+                            level="warning",
+                        )
+                        self._stop_event.wait(e.retry_after)

--- a/sekoia_automation/backoff.py
+++ b/sekoia_automation/backoff.py
@@ -1,0 +1,75 @@
+"""
+Backoff helpers pacing the trigger and connector run loops.
+
+Thin `tenacity` factories: a loop that restarts a failed cycle needs a growing
+pause, otherwise a permanent failure busy-loops. The stop event is used both as
+the stop condition and as the sleep, so SIGTERM stays immediate mid-backoff.
+"""
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from threading import Event
+
+from tenacity import (
+    AsyncRetrying,
+    RetryCallState,
+    Retrying,
+    sleep_using_event,
+    stop_when_event_set,
+    wait_exponential_jitter,
+)
+
+DEFAULT_MAX_DELAY = 300.0
+
+# Absolute seconds, not a fraction of the delay. Tenacity's 1s default is too
+# small to desynchronize a fleet failing against the same endpoint.
+DEFAULT_JITTER = 30.0
+
+BeforeSleep = Callable[[RetryCallState], None] | None
+AsyncBeforeSleep = Callable[[RetryCallState], Awaitable[None] | None] | None
+
+
+def error_backoff(
+    stop_event: Event,
+    before_sleep: BeforeSleep = None,
+    max_delay: float = DEFAULT_MAX_DELAY,
+    jitter: float = DEFAULT_JITTER,
+) -> Retrying:
+    """
+    Build the controller pacing a synchronous run loop.
+
+    The delay grows across consecutive failures; a fresh controller resets it.
+    """
+    return Retrying(
+        stop=stop_when_event_set(stop_event),
+        wait=wait_exponential_jitter(max=max_delay, jitter=jitter),
+        sleep=sleep_using_event(stop_event),
+        before_sleep=before_sleep,
+        # Leave the loop quietly when stopped instead of raising RetryError.
+        retry_error_callback=lambda _: None,
+    )
+
+
+def async_error_backoff(
+    stop_event: Event,
+    before_sleep: AsyncBeforeSleep = None,
+    max_delay: float = DEFAULT_MAX_DELAY,
+    jitter: float = DEFAULT_JITTER,
+) -> AsyncRetrying:
+    """
+    Build the controller pacing an asynchronous run loop.
+
+    `sleep_using_event` is synchronous, so the wait runs in a worker thread and
+    still returns as soon as the stop event is set.
+    """
+
+    async def sleep(seconds: float) -> None:
+        await asyncio.to_thread(stop_event.wait, seconds)
+
+    return AsyncRetrying(
+        stop=stop_when_event_set(stop_event),
+        wait=wait_exponential_jitter(max=max_delay, jitter=jitter),
+        sleep=sleep,
+        before_sleep=before_sleep,
+        retry_error_callback=lambda _: None,
+    )

--- a/sekoia_automation/connector/__init__.py
+++ b/sekoia_automation/connector/__init__.py
@@ -387,13 +387,16 @@ class Connector(Trigger, MetricsMixin, ABC):
             time.sleep(delta_sleep)
 
     def run(self) -> None:  # pragma: no cover
-        while self.running:
-            try:
-                self.next_run()
-            except Exception as e:
-                self.log_exception(
-                    e,
-                    message=f"Error while running connector {self.connector_name}",
-                )
+        log_backoff = self._log_backoff(
+            f"Error while running connector {self.connector_name}"
+        )
 
-                time.sleep(self.frequency)
+        while self.running:
+            # New controller per iteration, so the delay resets on success.
+            # `self.frequency` is not usable as a pause here: it defaults to 0.
+            for attempt in self._error_backoff(log_backoff):
+                with attempt:
+                    if not self.running:
+                        break
+
+                    self.next_run()

--- a/sekoia_automation/trigger.py
+++ b/sekoia_automation/trigger.py
@@ -1,7 +1,7 @@
 import json
 import signal
 from abc import abstractmethod
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -16,8 +16,23 @@ import sentry_sdk
 from cachetools import TLRUCache
 from pydantic import BaseModel
 from requests import HTTPError
-from tenacity import retry, stop_after_attempt, wait_exponential
+from tenacity import (
+    AsyncRetrying,
+    RetryCallState,
+    Retrying,
+    retry,
+    stop_after_attempt,
+    wait_exponential,
+)
 
+from sekoia_automation.backoff import (
+    DEFAULT_JITTER,
+    DEFAULT_MAX_DELAY,
+    AsyncBeforeSleep,
+    BeforeSleep,
+    async_error_backoff,
+    error_backoff,
+)
 from sekoia_automation.exceptions import (
     InvalidDirectoryError,
     ModuleConfigurationError,
@@ -33,6 +48,10 @@ from sekoia_automation.utils import (
     get_as_model,
     validate_with_model,
 )
+
+
+class _RunAbortedError(Exception):
+    """Tells the retry controller that `run` failed. The error is already logged."""
 
 
 class Trigger(ModuleItem):
@@ -64,6 +83,11 @@ class Trigger(ModuleItem):
 
     # Time to wait for stop event to be received
     _STOP_EVENT_WAIT = 120
+
+    # Pacing applied by the run loops after a failed cycle, so that a permanent
+    # failure does not busy-loop.
+    ERROR_BACKOFF_MAX = DEFAULT_MAX_DELAY
+    ERROR_BACKOFF_JITTER = DEFAULT_JITTER
 
     def __init__(self, module: Module | None = None, data_path: Path | None = None):
         super().__init__(module, data_path)
@@ -163,9 +187,56 @@ class Trigger(ModuleItem):
         elif self._configuration:
             sentry_sdk.set_context("trigger_configuration", self._configuration)
 
-    def _execute_once(self) -> None:
+    def _error_backoff(self, before_sleep: BeforeSleep = None) -> Retrying:
+        """Build the controller pacing a synchronous run loop."""
+        return error_backoff(
+            self._stop_event,
+            before_sleep=before_sleep,
+            max_delay=self.ERROR_BACKOFF_MAX,
+            jitter=self.ERROR_BACKOFF_JITTER,
+        )
+
+    def _async_error_backoff(
+        self, before_sleep: AsyncBeforeSleep = None
+    ) -> AsyncRetrying:
+        """Build the controller pacing an asynchronous run loop."""
+        return async_error_backoff(
+            self._stop_event,
+            before_sleep=before_sleep,
+            max_delay=self.ERROR_BACKOFF_MAX,
+            jitter=self.ERROR_BACKOFF_JITTER,
+        )
+
+    def _log_backoff(self, description: str) -> Callable[[RetryCallState], None]:
+        """Build a `before_sleep` hook logging the failure being retried."""
+
+        def hook(retry_state: RetryCallState) -> None:
+            outcome = retry_state.outcome
+            exception = outcome.exception() if outcome is not None else None
+
+            # Constant message: `log` rate-limits per message, so interpolating
+            # the delay would send one log per failed cycle.
+            message = f"{description}. Retrying with an exponential backoff"
+
+            if isinstance(exception, Exception):
+                self.log_exception(exception, message=message)
+            else:
+                # No outcome, or a BaseException `log_exception` cannot take.
+                self.log(message=message, level="error")
+
+        return hook
+
+    def _execute_once(self) -> bool:
+        """
+        Run the trigger once.
+
+        Returns:
+            bool: whether `run` completed without raising.
+        """
+        succeeded = False
         try:
             self.run()
+            succeeded = True
         # Configuration errors are considered to be critical
         except (TriggerConfigurationError, ModuleConfigurationError) as e:
             self.log_exception(e)
@@ -187,6 +258,7 @@ class Trigger(ModuleItem):
             # Prevent the trigger from running
             # and creating other errors until it is stopped
             self._stop_event.wait(self._STOP_EVENT_WAIT)
+        return succeeded
 
     def execute(self) -> None:
         self._ensure_data_path_set()
@@ -196,13 +268,24 @@ class Trigger(ModuleItem):
         self._logs_timer.start()
         try:
             while not self._stop_event.is_set():
-                try:
-                    self._execute_once()
-                except Exception:  # pragma: no cover
-                    # Exception are handled in `_execute_once` but in case
-                    # an error occurred while handling an error we catch everything
-                    # i.e. An error occurred while sending logs to Sekoia.io
-                    pass
+                # New controller per iteration, so the delay resets once `run`
+                # completes. `_execute_once` already logged, hence no hook.
+                for attempt in self._error_backoff():
+                    with attempt:
+                        if not self.running:
+                            break
+
+                        try:
+                            failed = not self._execute_once()
+                        except Exception:  # pragma: no cover
+                            # `_execute_once` handles its own errors, so this
+                            # only catches errors raised while handling one,
+                            # i.e. while sending logs to Sekoia.io
+                            failed = True
+
+                        if failed:
+                            # Raise so the controller paces the next start.
+                            raise _RunAbortedError
         finally:
             # Send remaining logs if any
             self._send_logs_to_api()

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -1,0 +1,147 @@
+from threading import Event
+
+import pytest
+
+from sekoia_automation import backoff
+from sekoia_automation.backoff import async_error_backoff, error_backoff
+
+
+@pytest.fixture
+def recorded_delays(monkeypatch):
+    """Record every delay the synchronous controller waits for."""
+    delays: list[float] = []
+    monkeypatch.setattr(backoff, "sleep_using_event", lambda event: delays.append)
+    return delays
+
+
+@pytest.fixture
+def recorded_async_delays(monkeypatch):
+    """Record every delay the asynchronous controller waits for."""
+    delays: list[float] = []
+
+    async def to_thread(_wait, seconds):
+        delays.append(seconds)
+
+    monkeypatch.setattr(backoff.asyncio, "to_thread", to_thread)
+    return delays
+
+
+def test_error_backoff_waits_between_consecutive_failures(recorded_delays):
+    attempts = 0
+
+    for attempt in error_backoff(Event(), max_delay=60, jitter=0):
+        with attempt:
+            attempts += 1
+            if attempts < 4:
+                raise ValueError("boom")
+
+    assert attempts == 4
+    # No pause before the first attempt.
+    assert recorded_delays == [1, 2, 4]
+
+
+def test_error_backoff_caps_the_delay(recorded_delays):
+    attempts = 0
+
+    for attempt in error_backoff(Event(), max_delay=3, jitter=0):
+        with attempt:
+            attempts += 1
+            if attempts < 5:
+                raise ValueError("boom")
+
+    assert recorded_delays == [1, 2, 3, 3]
+
+
+def test_error_backoff_resets_on_a_new_controller(recorded_delays):
+    stop_event = Event()
+
+    for _ in range(2):
+        attempts = 0
+        for attempt in error_backoff(stop_event, max_delay=60, jitter=0):
+            with attempt:
+                attempts += 1
+                if attempts < 3:
+                    raise ValueError("boom")
+
+    # Second controller restarts from 1s instead of carrying the first streak.
+    assert recorded_delays == [1, 2, 1, 2]
+
+
+def test_error_backoff_leaves_the_loop_when_stopped(recorded_delays):
+    stop_event = Event()
+    stop_event.set()
+    attempts = 0
+
+    # No RetryError: a stopped item must leave the loop quietly.
+    for attempt in error_backoff(stop_event, max_delay=60, jitter=0):
+        with attempt:
+            attempts += 1
+            raise ValueError("boom")
+
+    assert attempts == 1
+    assert recorded_delays == []
+
+
+def test_error_backoff_calls_before_sleep(recorded_delays):
+    seen: list[str] = []
+    attempts = 0
+
+    for attempt in error_backoff(
+        Event(),
+        before_sleep=lambda state: seen.append(str(state.outcome.exception())),
+        max_delay=60,
+        jitter=0,
+    ):
+        with attempt:
+            attempts += 1
+            if attempts < 3:
+                raise ValueError("boom")
+
+    assert seen == ["boom", "boom"]
+
+
+def test_error_backoff_adds_jitter(recorded_delays):
+    attempts = 0
+
+    for attempt in error_backoff(Event(), max_delay=60, jitter=10):
+        with attempt:
+            attempts += 1
+            if attempts < 4:
+                raise ValueError("boom")
+
+    assert len(recorded_delays) == 3
+    for expected, actual in zip([1, 2, 4], recorded_delays, strict=True):
+        assert expected <= actual <= expected + 10
+
+
+@pytest.mark.asyncio
+async def test_async_error_backoff_waits_between_consecutive_failures(
+    recorded_async_delays,
+):
+    attempts = 0
+
+    async for attempt in async_error_backoff(Event(), max_delay=60, jitter=0):
+        with attempt:
+            attempts += 1
+            if attempts < 4:
+                raise ValueError("boom")
+
+    assert attempts == 4
+    assert recorded_async_delays == [1, 2, 4]
+
+
+@pytest.mark.asyncio
+async def test_async_error_backoff_leaves_the_loop_when_stopped(
+    recorded_async_delays,
+):
+    stop_event = Event()
+    stop_event.set()
+    attempts = 0
+
+    async for attempt in async_error_backoff(stop_event, max_delay=60, jitter=0):
+        with attempt:
+            attempts += 1
+            raise ValueError("boom")
+
+    assert attempts == 1
+    assert recorded_async_delays == []

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -173,6 +173,74 @@ def test_trigger_execute(mocked_trigger_logs):
         mock.assert_called_with("test", {})
 
 
+def test_execute_once_reports_whether_run_succeeded(mocked_trigger_logs):
+    with patch.object(Trigger, "send_event"):
+        assert DummyTrigger()._execute_once() is True
+
+    with patch("sentry_sdk.capture_exception"):
+        assert ErrorTrigger()._execute_once() is False
+
+
+def test_execute_paces_restarts_when_run_keeps_failing(mocked_trigger_logs):
+    """A trigger that always fails must not be restarted in a busy loop."""
+    delays: list[float] = []
+    runs = 0
+
+    class FailingTrigger(Trigger):
+        ERROR_BACKOFF_JITTER = 0  # keep the delays deterministic
+
+        def run(self):
+            nonlocal runs
+            runs += 1
+            if runs >= 4:
+                self.stop()
+            raise ValueError("boom")
+
+    trigger = FailingTrigger()
+
+    def record(_event):
+        return delays.append
+
+    with (
+        patch("sekoia_automation.backoff.sleep_using_event", record),
+        patch.object(Trigger, "_get_secrets_from_server", return_value={}),
+        patch.object(Module, "set_secrets"),
+        patch("sentry_sdk.capture_exception"),
+    ):
+        trigger.execute()
+
+    assert runs == 4
+    assert delays == [1, 2, 4]
+
+
+def test_execute_does_not_pace_a_successful_run(mocked_trigger_logs):
+    """A trigger completing normally is restarted immediately, as before."""
+    delays: list[float] = []
+    runs = 0
+
+    class OneShotTrigger(Trigger):
+        def run(self):
+            nonlocal runs
+            runs += 1
+            if runs >= 3:
+                self.stop()
+
+    trigger = OneShotTrigger()
+
+    def record(_event):
+        return delays.append
+
+    with (
+        patch("sekoia_automation.backoff.sleep_using_event", record),
+        patch.object(Trigger, "_get_secrets_from_server", return_value={}),
+        patch.object(Module, "set_secrets"),
+    ):
+        trigger.execute()
+
+    assert runs == 3
+    assert delays == []
+
+
 def test_trigger_configuration_setter():
     trigger = DummyTrigger()
 


### PR DESCRIPTION
Possible fix for [1826](https://github.com/SekoiaLab/integration/issues/1826)

## Summary by Sourcery

Introduce exponential backoff controllers to pace trigger and connector run loops after failures, preventing busy-looping and high resource usage on permanent errors.

New Features:
- Add sekoia_automation.backoff module providing error_backoff and async_error_backoff helpers for synchronous and asynchronous run loops, with configurable maximum delay and jitter.

Bug Fixes:
- Ensure Trigger.execute, Connector.run, AsyncConnector.async_run, AssetConnector.run and AsyncAssetConnector.async_run no longer restart failed cycles immediately, avoiding CPU saturation and excessive API calls on permanent failures.
- Prevent run loops from relying on a zero default frequency for pause logic, ensuring actual backoff is applied on errors.

Enhancements:
- Make Trigger._execute_once report whether run completed successfully so callers can decide when to trigger backoff.
- Add structured logging hooks around backoff retries so repeated failures are logged consistently without creating log floods.

Documentation:
- Update CHANGELOG to document the new backoff helpers and the fix to busy-looping run loops.

Tests:
- Add unit tests for the new backoff helpers, covering delay growth, capping, jitter, stop-event handling, and the async variant.
- Add tests validating Trigger.execute backoff behaviour and ensuring successful runs are not unnecessarily delayed.